### PR TITLE
Support `lazy` schema's for recursive structures

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -14,6 +14,7 @@
     ],
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
+        "Skinney/murmur3": "2.0.4 <= v < 3.0.0",
         "elm-community/elm-test": "3.1.0 <= v < 4.0.0",
         "elm-community/maybe-extra": "3.1.0 <= v < 4.0.0",
         "elm-community/shrink": "2.0.0 <= v < 3.0.0",

--- a/src/JsonSchema.elm
+++ b/src/JsonSchema.elm
@@ -1,4 +1,4 @@
-module JsonSchema exposing (Schema, required, optional, title, description, enum, minimum, maximum, properties, items, minItems, maxItems, minLength, maxLength, pattern, format, dateTime, email, hostname, ipv4, ipv6, uri, customFormat, object, array, string, integer, number, boolean, null, oneOf, allOf, anyOf)
+module JsonSchema exposing (Schema, required, optional, title, description, enum, minimum, maximum, properties, items, minItems, maxItems, minLength, maxLength, pattern, format, dateTime, email, hostname, ipv4, ipv6, uri, customFormat, object, array, string, integer, number, boolean, null, oneOf, allOf, anyOf, lazy)
 
 {-| This library allows you to write your json schema files in elm, preventing inadvertent errors.
 
@@ -6,7 +6,7 @@ module JsonSchema exposing (Schema, required, optional, title, description, enum
 @docs Schema
 
 # Schema types
-@docs object, array, string, integer, number, boolean, null, oneOf, allOf, anyOf
+@docs object, array, string, integer, number, boolean, null, oneOf, allOf, anyOf, lazy
 
 # Keywords
 @docs title, description, enum, minimum, maximum, properties, items, minItems, maxItems, minLength, maxLength, pattern, format
@@ -361,3 +361,10 @@ anyOf : List BaseCombinatorSchemaProperty -> List Schema -> Schema
 anyOf props subSchemas =
     List.foldl (<|) { defaultCombinatorSchema | subSchemas = subSchemas } props
         |> AnyOf
+
+
+{-| Create a lazy type schema.
+-}
+lazy : (() -> Schema) -> Schema
+lazy thunk =
+    Lazy thunk

--- a/src/JsonSchema/Decoder.elm
+++ b/src/JsonSchema/Decoder.elm
@@ -74,6 +74,7 @@ decoder =
                     |> required "allOf" (list decoder)
                     |> optionalMaybe "title" string
                     |> optionalMaybe "description" string
+                , map Fallback value
                 ]
         )
 

--- a/src/JsonSchema/Encoder.elm
+++ b/src/JsonSchema/Encoder.elm
@@ -5,8 +5,10 @@ module JsonSchema.Encoder exposing (encode, encodeValue, EncoderProgram, encodeS
 @docs encode, encodeValue, EncoderProgram, encodeSchemaProgram
 -}
 
-import JsonSchema.Model exposing (..)
+import Dict exposing (Dict)
 import Json.Encode as Encode
+import JsonSchema.Model exposing (..)
+import JsonSchema.Util exposing (hash)
 import Maybe.Extra
 
 
@@ -36,36 +38,58 @@ encodeSchemaProgram schema emit =
 -}
 encode : Schema -> String
 encode schema =
-    schema
-        |> encodeValue
-        |> Encode.encode 2
+    let
+        cache : ThunkCache
+        cache =
+            findThunks schema Dict.empty
+
+        definitions : Maybe ( String, Encode.Value )
+        definitions =
+            if Dict.isEmpty cache then
+                Nothing
+            else
+                Dict.toList cache
+                    |> List.map (Tuple.mapSecond <| encodeValue cache)
+                    |> Encode.object
+                    |> ((,) "definitions")
+                    |> Just
+    in
+        schema
+            |> preEncodeValue cache
+            |> ((::) definitions)
+            |> Maybe.Extra.values
+            |> Encode.object
+            |> Encode.encode 2
 
 
 {-| Encode an elm json schema into a json value.
 -}
-encodeValue : Schema -> Encode.Value
-encodeValue schema =
+encodeValue : ThunkCache -> Schema -> Encode.Value
+encodeValue cache schema =
+    preEncodeValue cache schema
+        |> Maybe.Extra.values
+        |> Encode.object
+
+
+preEncodeValue : ThunkCache -> Schema -> List (Maybe ( String, Encode.Value ))
+preEncodeValue cache schema =
     case schema of
         Object objectSchema ->
             [ Just ( "type", Encode.string "object" )
             , Maybe.map ((,) "title" << Encode.string) objectSchema.title
             , Maybe.map ((,) "description" << Encode.string) objectSchema.description
-            , Just ( "properties", (convertProperty objectSchema.properties) )
+            , Just ( "properties", (convertProperty cache objectSchema.properties) )
             , Just ( "required", (findRequiredFields objectSchema.properties) )
             ]
-                |> Maybe.Extra.values
-                |> Encode.object
 
         Array arraySchema ->
             [ Just ( "type", Encode.string "array" )
             , Maybe.map ((,) "title" << Encode.string) arraySchema.title
             , Maybe.map ((,) "description" << Encode.string) arraySchema.description
-            , Maybe.map ((,) "items" << encodeValue) arraySchema.items
+            , Maybe.map ((,) "items" << encodeValue cache) arraySchema.items
             , Maybe.map ((,) "minItems" << Encode.int) arraySchema.minItems
             , Maybe.map ((,) "maxItems" << Encode.int) arraySchema.maxItems
             ]
-                |> Maybe.Extra.values
-                |> Encode.object
 
         String stringSchema ->
             [ Just ( "type", Encode.string "string" )
@@ -77,8 +101,6 @@ encodeValue schema =
             , Maybe.map ((,) "pattern" << Encode.string) stringSchema.pattern
             , Maybe.map ((,) "format" << Encode.string << printFormat) stringSchema.format
             ]
-                |> Maybe.Extra.values
-                |> Encode.object
 
         Integer integerSchema ->
             [ Just ( "type", Encode.string "integer" )
@@ -88,8 +110,6 @@ encodeValue schema =
             , Maybe.map ((,) "minimum" << Encode.int) integerSchema.minimum
             , Maybe.map ((,) "maximum" << Encode.int) integerSchema.maximum
             ]
-                |> Maybe.Extra.values
-                |> Encode.object
 
         Number numberSchema ->
             [ Just ( "type", Encode.string "number" )
@@ -99,70 +119,132 @@ encodeValue schema =
             , Maybe.map ((,) "minimum" << Encode.float) numberSchema.minimum
             , Maybe.map ((,) "maximum" << Encode.float) numberSchema.maximum
             ]
-                |> Maybe.Extra.values
-                |> Encode.object
 
         Boolean booleanSchema ->
             [ Just ( "type", Encode.string "boolean" )
             , Maybe.map ((,) "title" << Encode.string) booleanSchema.title
             , Maybe.map ((,) "description" << Encode.string) booleanSchema.description
             ]
-                |> Maybe.Extra.values
-                |> Encode.object
 
         Null nullSchema ->
             [ Just ( "type", Encode.string "null" )
             , Maybe.map ((,) "title" << Encode.string) nullSchema.title
             , Maybe.map ((,) "description" << Encode.string) nullSchema.description
             ]
-                |> Maybe.Extra.values
-                |> Encode.object
 
         OneOf oneOfSchema ->
             [ Maybe.map ((,) "title" << Encode.string) oneOfSchema.title
             , Maybe.map ((,) "description" << Encode.string) oneOfSchema.description
-            , List.map encodeValue oneOfSchema.subSchemas
+            , List.map (encodeValue cache) oneOfSchema.subSchemas
                 |> Encode.list
                 |> (,) "oneOf"
                 |> Just
             ]
-                |> Maybe.Extra.values
-                |> Encode.object
 
         AnyOf anyOfSchema ->
             [ Maybe.map ((,) "title" << Encode.string) anyOfSchema.title
             , Maybe.map ((,) "description" << Encode.string) anyOfSchema.description
-            , List.map encodeValue anyOfSchema.subSchemas
+            , List.map (encodeValue cache) anyOfSchema.subSchemas
                 |> Encode.list
                 |> (,) "anyOf"
                 |> Just
             ]
-                |> Maybe.Extra.values
-                |> Encode.object
 
         AllOf allOfSchema ->
             [ Maybe.map ((,) "title" << Encode.string) allOfSchema.title
             , Maybe.map ((,) "description" << Encode.string) allOfSchema.description
-            , List.map encodeValue allOfSchema.subSchemas
+            , List.map (encodeValue cache) allOfSchema.subSchemas
                 |> Encode.list
                 |> (,) "allOf"
                 |> Just
             ]
-                |> Maybe.Extra.values
-                |> Encode.object
+
+        Lazy thunk ->
+            [ Just ( "$ref", Encode.string <| "#/definitions/" ++ (hash <| thunk ()) ) ]
 
 
-convertProperty : List ObjectProperty -> Encode.Value
-convertProperty properties =
+type alias ThunkCache =
+    Dict String Schema
+
+
+findThunks : Schema -> ThunkCache -> ThunkCache
+findThunks schema cache =
+    case schema of
+        Object { properties } ->
+            List.map getPropertySchema properties
+                |> List.foldr findThunks cache
+
+        Array { items } ->
+            Maybe.Extra.unwrap cache (flip findThunks cache) items
+
+        String _ ->
+            cache
+
+        Integer _ ->
+            cache
+
+        Number _ ->
+            cache
+
+        Boolean _ ->
+            cache
+
+        Null _ ->
+            cache
+
+        OneOf { subSchemas } ->
+            List.foldr findThunks cache subSchemas
+
+        AnyOf { subSchemas } ->
+            List.foldr findThunks cache subSchemas
+
+        AllOf { subSchemas } ->
+            List.foldr findThunks cache subSchemas
+
+        Lazy thunk ->
+            thunkDict thunk cache
+
+
+getPropertySchema : ObjectProperty -> Schema
+getPropertySchema property =
+    case property of
+        Required _ schema ->
+            schema
+
+        Optional _ schema ->
+            schema
+
+
+thunkDict : (() -> Schema) -> ThunkCache -> ThunkCache
+thunkDict thunk cache =
+    let
+        schema : Schema
+        schema =
+            thunk ()
+
+        key : String
+        key =
+            hash schema
+    in
+        if Dict.member key cache then
+            cache
+        else
+            cache
+                |> Dict.insert key schema
+                |> findThunks schema
+
+
+convertProperty : ThunkCache -> List ObjectProperty -> Encode.Value
+convertProperty cache properties =
     properties
         |> List.map
             (\property ->
                 case property of
                     Required name schema ->
-                        ( name, encodeValue schema )
+                        ( name, encodeValue cache schema )
 
                     Optional name schema ->
-                        ( name, encodeValue schema )
+                        ( name, encodeValue cache schema )
             )
         |> Encode.object
 

--- a/src/JsonSchema/Encoder.elm
+++ b/src/JsonSchema/Encoder.elm
@@ -136,6 +136,14 @@ encodeSubSchema cache schema =
                 |> Maybe.Extra.values
                 |> Encode.object
 
+        Ref refSchema ->
+            [ Just ( "$ref", Encode.string refSchema.ref )
+            , Maybe.map ((,) "title" << Encode.string) refSchema.title
+            , Maybe.map ((,) "description" << Encode.string) refSchema.description
+            ]
+                |> Maybe.Extra.values
+                |> Encode.object
+
         Null nullSchema ->
             [ Just ( "type", Encode.string "null" )
             , Maybe.map ((,) "title" << Encode.string) nullSchema.title
@@ -212,6 +220,9 @@ findThunks schema cache =
             cache
 
         Null _ ->
+            cache
+
+        Ref _ ->
             cache
 
         OneOf { subSchemas } ->

--- a/src/JsonSchema/Fuzz.elm
+++ b/src/JsonSchema/Fuzz.elm
@@ -58,6 +58,9 @@ schemaValue schema =
         AllOf allOfSchema ->
             Debug.crash "Fuzzing an allOf schema is currently not supported"
 
+        Lazy thunk ->
+            Debug.crash "Fuzzing a lazy schema is currently not supported"
+
 
 objectFuzzer : ObjectSchema -> Fuzzer Value
 objectFuzzer objectSchema =

--- a/src/JsonSchema/Fuzz.elm
+++ b/src/JsonSchema/Fuzz.elm
@@ -61,6 +61,9 @@ schemaValue schema =
         Lazy thunk ->
             Debug.crash "Fuzzing a lazy schema is currently not supported"
 
+        Fallback value ->
+            Debug.crash "Fuzzing a fallback schema is not supported"
+
 
 objectFuzzer : ObjectSchema -> Fuzzer Value
 objectFuzzer objectSchema =

--- a/src/JsonSchema/Fuzz.elm
+++ b/src/JsonSchema/Fuzz.elm
@@ -47,6 +47,9 @@ schemaValue schema =
         Null _ ->
             nullFuzzer
 
+        Ref _ ->
+            Debug.crash "Fuzzing a ref schema is not supported"
+
         AnyOf anyOfSchema ->
             anyOfFuzzer anyOfSchema
 

--- a/src/JsonSchema/Model.elm
+++ b/src/JsonSchema/Model.elm
@@ -12,6 +12,7 @@ type Schema
     | OneOf BaseCombinatorSchema
     | AnyOf BaseCombinatorSchema
     | AllOf BaseCombinatorSchema
+    | Lazy (() -> Schema)
 
 
 type alias BaseSchema extras =

--- a/src/JsonSchema/Model.elm
+++ b/src/JsonSchema/Model.elm
@@ -1,5 +1,7 @@
 module JsonSchema.Model exposing (..)
 
+import Json.Decode
+
 
 type Schema
     = Object ObjectSchema
@@ -13,6 +15,7 @@ type Schema
     | AnyOf BaseCombinatorSchema
     | AllOf BaseCombinatorSchema
     | Lazy (() -> Schema)
+    | Fallback Json.Decode.Value
 
 
 type alias BaseSchema extras =

--- a/src/JsonSchema/Model.elm
+++ b/src/JsonSchema/Model.elm
@@ -11,6 +11,7 @@ type Schema
     | Number NumberSchema
     | Boolean (BaseSchema {})
     | Null (BaseSchema {})
+    | Ref RefSchema
     | OneOf BaseCombinatorSchema
     | AnyOf BaseCombinatorSchema
     | AllOf BaseCombinatorSchema
@@ -76,6 +77,12 @@ type alias StringSchema =
             , format : Maybe StringFormat
             }
         )
+
+
+type alias RefSchema =
+    BaseSchema
+        { ref : String
+        }
 
 
 type alias BaseCombinatorSchema =

--- a/src/JsonSchema/Util.elm
+++ b/src/JsonSchema/Util.elm
@@ -1,0 +1,11 @@
+module JsonSchema.Util exposing (..)
+
+import JsonSchema.Model exposing (Schema)
+import Murmur3
+
+
+hash : Schema -> String
+hash schema =
+    toString schema
+        |> Murmur3.hashString 1234
+        |> toString

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -3,6 +3,7 @@ port module Main exposing (..)
 import Tests
 import Test
 import SchemaFuzzSpec
+import DecoderSpec
 import Test.Runner.Node exposing (run, TestProgram)
 import Json.Encode exposing (Value)
 
@@ -11,6 +12,7 @@ main : TestProgram
 main =
     [ Tests.spec
     , SchemaFuzzSpec.spec
+    , DecoderSpec.spec
     ]
         |> Test.concat
         |> run emit

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -12,6 +12,7 @@
     "native-modules": true,
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
+        "Skinney/murmur3": "2.0.4 <= v < 3.0.0",
         "elm-community/elm-test": "3.1.0 <= v < 4.0.0",
         "elm-community/json-extra": "2.0.0 <= v < 3.0.0",
         "elm-community/maybe-extra": "3.1.0 <= v < 4.0.0",

--- a/tests/specs/DecoderSpec.elm
+++ b/tests/specs/DecoderSpec.elm
@@ -3,9 +3,11 @@ module DecoderSpec exposing (spec)
 import Expect exposing (pass)
 import Fixtures
 import Json.Decode as Decode
+import Json.Encode as Encode
 import JsonSchema exposing (..)
 import JsonSchema.Decoder exposing (decoder)
 import JsonSchema.Encoder exposing (encode)
+import JsonSchema.Model
 import Test exposing (..)
 
 
@@ -33,6 +35,7 @@ spec =
             , string [ format ipv6 ]
             , string [ format uri ]
             , string [ format (customFormat "foo") ]
+            , JsonSchema.Model.Fallback (Encode.object [ ( "foo", Encode.string "bar" ) ])
               -- , Fixtures.lazySchema
             ]
 

--- a/tests/specs/DecoderSpec.elm
+++ b/tests/specs/DecoderSpec.elm
@@ -28,6 +28,7 @@ spec =
             , Fixtures.oneOfSchema
             , Fixtures.anyOfSchema
             , Fixtures.allOfSchema
+            , Fixtures.fallbackSchema
             , string [ format dateTime ]
             , string [ format email ]
             , string [ format hostname ]
@@ -35,7 +36,6 @@ spec =
             , string [ format ipv6 ]
             , string [ format uri ]
             , string [ format (customFormat "foo") ]
-            , JsonSchema.Model.Fallback (Encode.object [ ( "foo", Encode.string "bar" ) ])
               -- , Fixtures.lazySchema
             ]
 

--- a/tests/specs/DecoderSpec.elm
+++ b/tests/specs/DecoderSpec.elm
@@ -1,0 +1,56 @@
+module DecoderSpec exposing (spec)
+
+import Expect exposing (pass)
+import Fixtures
+import Json.Decode as Decode
+import JsonSchema exposing (..)
+import JsonSchema.Decoder exposing (decoder)
+import JsonSchema.Encoder exposing (encode)
+import Test exposing (..)
+
+
+spec : Test
+spec =
+    describe "Decoder" <|
+        List.map testSchemaDecoder
+            [ Fixtures.objectSchema
+            , Fixtures.arraySchema
+            , Fixtures.stringSchema
+            , Fixtures.stringEnumSchema
+            , Fixtures.integerEnumSchema
+            , Fixtures.integerSchema
+            , Fixtures.numberSchema
+            , Fixtures.numberEnumSchema
+            , Fixtures.booleanSchema
+            , Fixtures.nullSchema
+            , Fixtures.oneOfSchema
+            , Fixtures.anyOfSchema
+            , Fixtures.allOfSchema
+            , string [ format dateTime ]
+            , string [ format email ]
+            , string [ format hostname ]
+            , string [ format ipv4 ]
+            , string [ format ipv6 ]
+            , string [ format uri ]
+            , string [ format (customFormat "foo") ]
+              -- , Fixtures.lazySchema
+            ]
+
+
+{-| Test a decoder by taking a json schema string, decoding and then encoding it and expecting the same result as before.
+To make it easier to write this test, we generate the json schema string to test from an elm schema.
+This means that in practice, we test 1. encode -> 2. decode -> 3. encode, comparing the output from 1 and 3.
+-}
+testSchemaDecoder : Schema -> Test
+testSchemaDecoder schema =
+    let
+        jsonSchema : String
+        jsonSchema =
+            encode schema
+    in
+        test ("decoding work with schema: " ++ jsonSchema) <|
+            \_ ->
+                jsonSchema
+                    |> Decode.decodeString decoder
+                    |> Result.map encode
+                    |> Expect.equal (Ok jsonSchema)

--- a/tests/specs/DecoderSpec.elm
+++ b/tests/specs/DecoderSpec.elm
@@ -3,11 +3,9 @@ module DecoderSpec exposing (spec)
 import Expect exposing (pass)
 import Fixtures
 import Json.Decode as Decode
-import Json.Encode as Encode
 import JsonSchema exposing (..)
 import JsonSchema.Decoder exposing (decoder)
 import JsonSchema.Encoder exposing (encode)
-import JsonSchema.Model
 import Test exposing (..)
 
 
@@ -25,10 +23,12 @@ spec =
             , Fixtures.numberEnumSchema
             , Fixtures.booleanSchema
             , Fixtures.nullSchema
+            , Fixtures.refSchema
             , Fixtures.oneOfSchema
             , Fixtures.anyOfSchema
             , Fixtures.allOfSchema
             , Fixtures.fallbackSchema
+            , Fixtures.lazySchema
             , string [ format dateTime ]
             , string [ format email ]
             , string [ format hostname ]
@@ -36,7 +36,6 @@ spec =
             , string [ format ipv6 ]
             , string [ format uri ]
             , string [ format (customFormat "foo") ]
-              -- , Fixtures.lazySchema
             ]
 
 

--- a/tests/specs/Fixtures.elm
+++ b/tests/specs/Fixtures.elm
@@ -1,0 +1,132 @@
+module Fixtures exposing (..)
+
+import JsonSchema exposing (..)
+
+
+objectSchema : Schema
+objectSchema =
+    object
+        [ title "object schema title"
+        , description "object schema description"
+        , properties
+            [ optional "firstName" <| string []
+            , required "lastName" <| string []
+            ]
+        ]
+
+
+arraySchema : Schema
+arraySchema =
+    array
+        [ title "array schema title"
+        , description "array schema description"
+        , items <| string []
+        , minItems 3
+        , maxItems 6
+        ]
+
+
+stringSchema : Schema
+stringSchema =
+    string
+        [ title "string schema title"
+        , description "string schema description"
+        , minLength 2
+        , maxLength 8
+        , pattern "^foo$"
+        , format dateTime
+        ]
+
+
+stringEnumSchema : Schema
+stringEnumSchema =
+    string
+        [ title "string schema title"
+        , enum [ "a", "b" ]
+        ]
+
+
+integerEnumSchema : Schema
+integerEnumSchema =
+    integer
+        [ title "integer schema title"
+        , enum [ 1, 2 ]
+        ]
+
+
+integerSchema : Schema
+integerSchema =
+    integer
+        [ title "integer schema title"
+        , description "integer schema description"
+        , minimum 2
+        , maximum 8
+        ]
+
+
+numberSchema : Schema
+numberSchema =
+    number
+        [ title "number schema title"
+        , description "number schema description"
+        , minimum 2.5
+        , maximum 8.3
+        ]
+
+
+numberEnumSchema : Schema
+numberEnumSchema =
+    number
+        [ title "number schema title"
+        , enum [ 1.2, 3.4 ]
+        ]
+
+
+booleanSchema : Schema
+booleanSchema =
+    boolean
+        [ title "boolean schema title"
+        , description "boolean schema description"
+        ]
+
+
+nullSchema : Schema
+nullSchema =
+    null
+        [ title "null schema title"
+        , description "null schema description"
+        ]
+
+
+oneOfSchema : Schema
+oneOfSchema =
+    oneOf
+        [ title "oneOf schema title"
+        , description "oneOf schema description"
+        ]
+        [ integer [], string [] ]
+
+
+anyOfSchema : Schema
+anyOfSchema =
+    anyOf
+        [ title "anyOf schema title"
+        , description "anyOf schema description"
+        ]
+        [ integer [], string [] ]
+
+
+allOfSchema : Schema
+allOfSchema =
+    allOf
+        [ title "allOf schema title"
+        , description "allOf schema description"
+        ]
+        [ integer [], string [] ]
+
+
+lazySchema : Schema
+lazySchema =
+    array
+        [ items <| lazy (\_ -> lazySchema)
+        ]

--- a/tests/specs/Fixtures.elm
+++ b/tests/specs/Fixtures.elm
@@ -100,6 +100,15 @@ nullSchema =
         ]
 
 
+refSchema : Schema
+refSchema =
+    JsonSchema.Model.Ref
+        { title = Just "ref schema title"
+        , description = Just "ref schema description"
+        , ref = "refurl"
+        }
+
+
 oneOfSchema : Schema
 oneOfSchema =
     oneOf

--- a/tests/specs/Fixtures.elm
+++ b/tests/specs/Fixtures.elm
@@ -1,6 +1,8 @@
 module Fixtures exposing (..)
 
+import Json.Encode as Encode
 import JsonSchema exposing (..)
+import JsonSchema.Model
 
 
 objectSchema : Schema
@@ -130,3 +132,11 @@ lazySchema =
     array
         [ items <| lazy (\_ -> lazySchema)
         ]
+
+
+fallbackSchema : Schema
+fallbackSchema =
+    JsonSchema.Model.Fallback
+        (Encode.object
+            [ ( "foo", Encode.string "bar" ) ]
+        )

--- a/tests/specs/Tests.elm
+++ b/tests/specs/Tests.elm
@@ -1,10 +1,10 @@
 module Tests exposing (spec)
 
 import Expect
+import Fixtures exposing (..)
 import Helpers exposing (expectAt, lengthAt, expectEqualResult)
 import Json.Decode as Decode
 import JsonSchema exposing (..)
-import JsonSchema.Decoder exposing (decoder)
 import JsonSchema.Encoder exposing (encode, encodeValue)
 import JsonSchema.Util exposing (hash)
 import Test exposing (..)
@@ -39,608 +39,418 @@ spec =
 
 objectSchemaSpec : Test
 objectSchemaSpec =
-    let
-        objectSchema : Schema
-        objectSchema =
-            object
-                [ title "object schema title"
-                , description "object schema description"
-                , properties
-                    [ optional "firstName" <| string []
-                    , required "lastName" <| string []
-                    ]
-                ]
-    in
-        describe "object schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode objectSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "object schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode objectSchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "object schema description" )
-            , test "has the right type" <|
-                \() ->
-                    encode objectSchema
-                        |> expectAt
-                            [ "type" ]
-                            ( Decode.string, "object" )
-            , test "adds the right properties to 'required'" <|
-                \() ->
-                    encode objectSchema
-                        |> expectAt
-                            [ "required", "0" ]
-                            ( Decode.string, "lastName" )
-            , test "array 'required' has correct length" <|
-                \() ->
-                    encode objectSchema
-                        |> lengthAt [ "required" ] 1
-            , test "first object property exists as nested schema" <|
-                \() ->
-                    encode objectSchema
-                        |> expectAt
-                            [ "properties", "firstName", "type" ]
-                            ( Decode.string, "string" )
-            , test "second object property exists as nested schema" <|
-                \() ->
-                    encode objectSchema
-                        |> expectAt
-                            [ "properties", "lastName", "type" ]
-                            ( Decode.string, "string" )
-            , test "decoder" <|
-                \() ->
-                    encode objectSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult objectSchema
-            ]
+    describe "object schema"
+        [ test "title property is set" <|
+            \() ->
+                encode objectSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "object schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode objectSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "object schema description" )
+        , test "has the right type" <|
+            \() ->
+                encode objectSchema
+                    |> expectAt
+                        [ "type" ]
+                        ( Decode.string, "object" )
+        , test "adds the right properties to 'required'" <|
+            \() ->
+                encode objectSchema
+                    |> expectAt
+                        [ "required", "0" ]
+                        ( Decode.string, "lastName" )
+        , test "array 'required' has correct length" <|
+            \() ->
+                encode objectSchema
+                    |> lengthAt [ "required" ] 1
+        , test "first object property exists as nested schema" <|
+            \() ->
+                encode objectSchema
+                    |> expectAt
+                        [ "properties", "firstName", "type" ]
+                        ( Decode.string, "string" )
+        , test "second object property exists as nested schema" <|
+            \() ->
+                encode objectSchema
+                    |> expectAt
+                        [ "properties", "lastName", "type" ]
+                        ( Decode.string, "string" )
+        ]
 
 
 arraySchemaSpec : Test
 arraySchemaSpec =
-    let
-        arraySchema : Schema
-        arraySchema =
-            array
-                [ title "array schema title"
-                , description "array schema description"
-                , items <| string []
-                , minItems 3
-                , maxItems 6
-                ]
-    in
-        describe "array schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode arraySchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "array schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode arraySchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "array schema description" )
-            , test "has the right type" <|
-                \() ->
-                    encode arraySchema
-                        |> expectAt
-                            [ "type" ]
-                            ( Decode.string, "array" )
-            , test "items property contains nested schema" <|
-                \() ->
-                    encode arraySchema
-                        |> expectAt
-                            [ "items", "type" ]
-                            ( Decode.string, "string" )
-            , test "minItems property contains nested schema" <|
-                \() ->
-                    encode arraySchema
-                        |> expectAt
-                            [ "minItems" ]
-                            ( Decode.int, 3 )
-            , test "maxItems property contains nested schema" <|
-                \() ->
-                    encode arraySchema
-                        |> expectAt
-                            [ "maxItems" ]
-                            ( Decode.int, 6 )
-            , test "decoder" <|
-                \() ->
-                    encode arraySchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult arraySchema
-            ]
+    describe "array schema"
+        [ test "title property is set" <|
+            \() ->
+                encode arraySchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "array schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode arraySchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "array schema description" )
+        , test "has the right type" <|
+            \() ->
+                encode arraySchema
+                    |> expectAt
+                        [ "type" ]
+                        ( Decode.string, "array" )
+        , test "items property contains nested schema" <|
+            \() ->
+                encode arraySchema
+                    |> expectAt
+                        [ "items", "type" ]
+                        ( Decode.string, "string" )
+        , test "minItems property contains nested schema" <|
+            \() ->
+                encode arraySchema
+                    |> expectAt
+                        [ "minItems" ]
+                        ( Decode.int, 3 )
+        , test "maxItems property contains nested schema" <|
+            \() ->
+                encode arraySchema
+                    |> expectAt
+                        [ "maxItems" ]
+                        ( Decode.int, 6 )
+        ]
 
 
 stringSchemaSpec : Test
 stringSchemaSpec =
-    let
-        stringSchema : Schema
-        stringSchema =
-            string
-                [ title "string schema title"
-                , description "string schema description"
-                , minLength 2
-                , maxLength 8
-                , pattern "^foo$"
-                , format dateTime
-                ]
-    in
-        describe "string schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode stringSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "string schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode stringSchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "string schema description" )
-            , test "has the right type" <|
-                \() ->
-                    encode stringSchema
-                        |> expectAt
-                            [ "type" ]
-                            ( Decode.string, "string" )
-            , test "minLength property is set" <|
-                \() ->
-                    encode stringSchema
-                        |> expectAt
-                            [ "minLength" ]
-                            ( Decode.int, 2 )
-            , test "maxLength property is set" <|
-                \() ->
-                    encode stringSchema
-                        |> expectAt
-                            [ "maxLength" ]
-                            ( Decode.int, 8 )
-            , test "pattern property is set" <|
-                \() ->
-                    encode stringSchema
-                        |> expectAt
-                            [ "pattern" ]
-                            ( Decode.string, "^foo$" )
-            , test "format property is set" <|
-                \() ->
-                    encode stringSchema
-                        |> expectAt
-                            [ "format" ]
-                            ( Decode.string, "date-time" )
-            , test "decoder" <|
-                \() ->
-                    encode stringSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult stringSchema
-            ]
+    describe "string schema"
+        [ test "title property is set" <|
+            \() ->
+                encode stringSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "string schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode stringSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "string schema description" )
+        , test "has the right type" <|
+            \() ->
+                encode stringSchema
+                    |> expectAt
+                        [ "type" ]
+                        ( Decode.string, "string" )
+        , test "minLength property is set" <|
+            \() ->
+                encode stringSchema
+                    |> expectAt
+                        [ "minLength" ]
+                        ( Decode.int, 2 )
+        , test "maxLength property is set" <|
+            \() ->
+                encode stringSchema
+                    |> expectAt
+                        [ "maxLength" ]
+                        ( Decode.int, 8 )
+        , test "pattern property is set" <|
+            \() ->
+                encode stringSchema
+                    |> expectAt
+                        [ "pattern" ]
+                        ( Decode.string, "^foo$" )
+        , test "format property is set" <|
+            \() ->
+                encode stringSchema
+                    |> expectAt
+                        [ "format" ]
+                        ( Decode.string, "date-time" )
+        ]
 
 
 stringEnumSchemaSpec : Test
 stringEnumSchemaSpec =
-    let
-        stringEnumSchema : Schema
-        stringEnumSchema =
-            string
-                [ title "string schema title"
-                , enum [ "a", "b" ]
-                ]
-    in
-        describe "string enum schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode stringEnumSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "string schema title" )
-            , test "enum property is set" <|
-                \() ->
-                    encode stringEnumSchema
-                        |> expectAt
-                            [ "enum" ]
-                            ( Decode.list Decode.string, [ "a", "b" ] )
-            , test "decoder" <|
-                \() ->
-                    encode stringEnumSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult stringEnumSchema
-            ]
+    describe "string enum schema"
+        [ test "title property is set" <|
+            \() ->
+                encode stringEnumSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "string schema title" )
+        , test "enum property is set" <|
+            \() ->
+                encode stringEnumSchema
+                    |> expectAt
+                        [ "enum" ]
+                        ( Decode.list Decode.string, [ "a", "b" ] )
+        ]
 
 
 integerEnumSchemaSpec : Test
 integerEnumSchemaSpec =
-    let
-        integerEnumSchema : Schema
-        integerEnumSchema =
-            integer
-                [ title "integer schema title"
-                , enum [ 1, 2 ]
-                ]
-    in
-        describe "integer enum schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode integerEnumSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "integer schema title" )
-            , test "enum property is set" <|
-                \() ->
-                    encode integerEnumSchema
-                        |> expectAt
-                            [ "enum" ]
-                            ( Decode.list Decode.int, [ 1, 2 ] )
-            , test "decoder" <|
-                \() ->
-                    encode integerEnumSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult integerEnumSchema
-            ]
+    describe "integer enum schema"
+        [ test "title property is set" <|
+            \() ->
+                encode integerEnumSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "integer schema title" )
+        , test "enum property is set" <|
+            \() ->
+                encode integerEnumSchema
+                    |> expectAt
+                        [ "enum" ]
+                        ( Decode.list Decode.int, [ 1, 2 ] )
+        ]
 
 
 integerSchemaSpec : Test
 integerSchemaSpec =
-    let
-        integerSchema : Schema
-        integerSchema =
-            integer
-                [ title "integer schema title"
-                , description "integer schema description"
-                , minimum 2
-                , maximum 8
-                ]
-    in
-        describe "integer schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode integerSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "integer schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode integerSchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "integer schema description" )
-            , test "has the right type" <|
-                \() ->
-                    encode integerSchema
-                        |> expectAt
-                            [ "type" ]
-                            ( Decode.string, "integer" )
-            , test "minimum property is set" <|
-                \() ->
-                    encode integerSchema
-                        |> expectAt
-                            [ "minimum" ]
-                            ( Decode.int, 2 )
-            , test "maximum property is set" <|
-                \() ->
-                    encode integerSchema
-                        |> expectAt
-                            [ "maximum" ]
-                            ( Decode.int, 8 )
-            , test "decoder" <|
-                \() ->
-                    encode integerSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult integerSchema
-            ]
+    describe "integer schema"
+        [ test "title property is set" <|
+            \() ->
+                encode integerSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "integer schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode integerSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "integer schema description" )
+        , test "has the right type" <|
+            \() ->
+                encode integerSchema
+                    |> expectAt
+                        [ "type" ]
+                        ( Decode.string, "integer" )
+        , test "minimum property is set" <|
+            \() ->
+                encode integerSchema
+                    |> expectAt
+                        [ "minimum" ]
+                        ( Decode.int, 2 )
+        , test "maximum property is set" <|
+            \() ->
+                encode integerSchema
+                    |> expectAt
+                        [ "maximum" ]
+                        ( Decode.int, 8 )
+        ]
 
 
 numberSchemaSpec : Test
 numberSchemaSpec =
-    let
-        numberSchema : Schema
-        numberSchema =
-            number
-                [ title "number schema title"
-                , description "number schema description"
-                , minimum 2.5
-                , maximum 8.3
-                ]
-    in
-        describe "number schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode numberSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "number schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode numberSchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "number schema description" )
-            , test "has the right type" <|
-                \() ->
-                    encode numberSchema
-                        |> expectAt
-                            [ "type" ]
-                            ( Decode.string, "number" )
-            , test "minimum property is set" <|
-                \() ->
-                    encode numberSchema
-                        |> expectAt
-                            [ "minimum" ]
-                            ( Decode.float, 2.5 )
-            , test "maximum property is set" <|
-                \() ->
-                    encode numberSchema
-                        |> expectAt
-                            [ "maximum" ]
-                            ( Decode.float, 8.3 )
-            , test "decoder" <|
-                \() ->
-                    encode numberSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult numberSchema
-            ]
+    describe "number schema"
+        [ test "title property is set" <|
+            \() ->
+                encode numberSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "number schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode numberSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "number schema description" )
+        , test "has the right type" <|
+            \() ->
+                encode numberSchema
+                    |> expectAt
+                        [ "type" ]
+                        ( Decode.string, "number" )
+        , test "minimum property is set" <|
+            \() ->
+                encode numberSchema
+                    |> expectAt
+                        [ "minimum" ]
+                        ( Decode.float, 2.5 )
+        , test "maximum property is set" <|
+            \() ->
+                encode numberSchema
+                    |> expectAt
+                        [ "maximum" ]
+                        ( Decode.float, 8.3 )
+        ]
 
 
 numberEnumSchemaSpec : Test
 numberEnumSchemaSpec =
-    let
-        numberEnumSchema : Schema
-        numberEnumSchema =
-            number
-                [ title "number schema title"
-                , enum [ 1.2, 3.4 ]
-                ]
-    in
-        describe "number schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode numberEnumSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "number schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode numberEnumSchema
-                        |> expectAt
-                            [ "enum" ]
-                            ( Decode.list Decode.float, [ 1.2, 3.4 ] )
-            , test "decoder" <|
-                \() ->
-                    encode numberEnumSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult numberEnumSchema
-            ]
+    describe "number schema"
+        [ test "title property is set" <|
+            \() ->
+                encode numberEnumSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "number schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode numberEnumSchema
+                    |> expectAt
+                        [ "enum" ]
+                        ( Decode.list Decode.float, [ 1.2, 3.4 ] )
+        ]
 
 
 booleanSchemaSpec : Test
 booleanSchemaSpec =
-    let
-        booleanSchema : Schema
-        booleanSchema =
-            boolean
-                [ title "boolean schema title"
-                , description "boolean schema description"
-                ]
-    in
-        describe "boolean schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode booleanSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "boolean schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode booleanSchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "boolean schema description" )
-            , test "has the right type" <|
-                \() ->
-                    encode booleanSchema
-                        |> expectAt
-                            [ "type" ]
-                            ( Decode.string, "boolean" )
-            , test "decoder" <|
-                \() ->
-                    encode booleanSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult booleanSchema
-            ]
+    describe "boolean schema"
+        [ test "title property is set" <|
+            \() ->
+                encode booleanSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "boolean schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode booleanSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "boolean schema description" )
+        , test "has the right type" <|
+            \() ->
+                encode booleanSchema
+                    |> expectAt
+                        [ "type" ]
+                        ( Decode.string, "boolean" )
+        ]
 
 
 nullSchemaSpec : Test
 nullSchemaSpec =
-    let
-        nullSchema : Schema
-        nullSchema =
-            null
-                [ title "null schema title"
-                , description "null schema description"
-                ]
-    in
-        describe "null schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode nullSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "null schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode nullSchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "null schema description" )
-            , test "has the right type" <|
-                \() ->
-                    encode nullSchema
-                        |> expectAt
-                            [ "type" ]
-                            ( Decode.string, "null" )
-            , test "decoder" <|
-                \() ->
-                    encode nullSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult nullSchema
-            ]
+    describe "null schema"
+        [ test "title property is set" <|
+            \() ->
+                encode nullSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "null schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode nullSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "null schema description" )
+        , test "has the right type" <|
+            \() ->
+                encode nullSchema
+                    |> expectAt
+                        [ "type" ]
+                        ( Decode.string, "null" )
+        ]
 
 
 oneOfSpec : Test
 oneOfSpec =
-    let
-        oneOfSchema =
-            oneOf
-                [ title "oneOf schema title"
-                , description "oneOf schema description"
-                ]
-                [ integer [], string [] ]
-    in
-        describe "oneOf schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode oneOfSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "oneOf schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode oneOfSchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "oneOf schema description" )
-            , test "subSchemas are set" <|
-                \() ->
-                    encode oneOfSchema
-                        |> Expect.all
-                            [ expectAt
-                                [ "oneOf", "0", "type" ]
-                                ( Decode.string, "integer" )
-                            , expectAt
-                                [ "oneOf", "1", "type" ]
-                                ( Decode.string, "string" )
-                            ]
-            , test "decoder" <|
-                \() ->
-                    encode oneOfSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult oneOfSchema
-            ]
+    describe "oneOf schema"
+        [ test "title property is set" <|
+            \() ->
+                encode oneOfSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "oneOf schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode oneOfSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "oneOf schema description" )
+        , test "subSchemas are set" <|
+            \() ->
+                encode oneOfSchema
+                    |> Expect.all
+                        [ expectAt
+                            [ "oneOf", "0", "type" ]
+                            ( Decode.string, "integer" )
+                        , expectAt
+                            [ "oneOf", "1", "type" ]
+                            ( Decode.string, "string" )
+                        ]
+        ]
 
 
 anyOfSpec : Test
 anyOfSpec =
-    let
-        anyOfSchema =
-            anyOf
-                [ title "anyOf schema title"
-                , description "anyOf schema description"
-                ]
-                [ integer [], string [] ]
-    in
-        describe "anyOf schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode anyOfSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "anyOf schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode anyOfSchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "anyOf schema description" )
-            , test "subSchemas are set" <|
-                \() ->
-                    encode anyOfSchema
-                        |> Expect.all
-                            [ expectAt
-                                [ "anyOf", "0", "type" ]
-                                ( Decode.string, "integer" )
-                            , expectAt
-                                [ "anyOf", "1", "type" ]
-                                ( Decode.string, "string" )
-                            ]
-            , test "decoder" <|
-                \() ->
-                    encode anyOfSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult anyOfSchema
-            ]
+    describe "anyOf schema"
+        [ test "title property is set" <|
+            \() ->
+                encode anyOfSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "anyOf schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode anyOfSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "anyOf schema description" )
+        , test "subSchemas are set" <|
+            \() ->
+                encode anyOfSchema
+                    |> Expect.all
+                        [ expectAt
+                            [ "anyOf", "0", "type" ]
+                            ( Decode.string, "integer" )
+                        , expectAt
+                            [ "anyOf", "1", "type" ]
+                            ( Decode.string, "string" )
+                        ]
+        ]
 
 
 allOfSpec : Test
 allOfSpec =
-    let
-        allOfSchema =
-            allOf
-                [ title "allOf schema title"
-                , description "allOf schema description"
-                ]
-                [ integer [], string [] ]
-    in
-        describe "allOf schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode allOfSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "allOf schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode allOfSchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "allOf schema description" )
-            , test "subSchemas are set" <|
-                \() ->
-                    encode allOfSchema
-                        |> Expect.all
-                            [ expectAt
-                                [ "allOf", "0", "type" ]
-                                ( Decode.string, "integer" )
-                            , expectAt
-                                [ "allOf", "1", "type" ]
-                                ( Decode.string, "string" )
-                            ]
-            , test "decoder" <|
-                \() ->
-                    encode allOfSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult allOfSchema
-            ]
+    describe "allOf schema"
+        [ test "title property is set" <|
+            \() ->
+                encode allOfSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "allOf schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode allOfSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "allOf schema description" )
+        , test "subSchemas are set" <|
+            \() ->
+                encode allOfSchema
+                    |> Expect.all
+                        [ expectAt
+                            [ "allOf", "0", "type" ]
+                            ( Decode.string, "integer" )
+                        , expectAt
+                            [ "allOf", "1", "type" ]
+                            ( Decode.string, "string" )
+                        ]
+        ]
 
 
 lazySchemaSpec : Test
 lazySchemaSpec =
     let
-        schema : Schema
-        schema =
-            array
-                [ items <| lazy (\_ -> schema)
-                ]
-
         key : String
         key =
-            hash schema
+            hash lazySchema
     in
         describe "lazy"
             [ test "is turned into a ref" <|
                 \() ->
-                    encode schema
+                    encode lazySchema
                         |> expectAt
                             [ "items", "$ref" ]
                             ( Decode.string, "#/definitions/" ++ key )
             , test "is turned into a ref" <|
                 \() ->
-                    encode schema
+                    encode lazySchema
                         |> expectAt
                             [ "definitions", key, "type" ]
                             ( Decode.string, "array" )
@@ -661,11 +471,6 @@ formatDateTime =
                         |> expectAt
                             [ "format" ]
                             ( Decode.string, "date-time" )
-            , test "decoder" <|
-                \() ->
-                    encode schema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult schema
             ]
 
 
@@ -683,11 +488,6 @@ formatEmail =
                         |> expectAt
                             [ "format" ]
                             ( Decode.string, "email" )
-            , test "decoder" <|
-                \() ->
-                    encode schema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult schema
             ]
 
 
@@ -705,11 +505,6 @@ formatHostname =
                         |> expectAt
                             [ "format" ]
                             ( Decode.string, "hostname" )
-            , test "decoder" <|
-                \() ->
-                    encode schema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult schema
             ]
 
 
@@ -727,11 +522,6 @@ formatIpv4 =
                         |> expectAt
                             [ "format" ]
                             ( Decode.string, "ipv4" )
-            , test "decoder" <|
-                \() ->
-                    encode schema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult schema
             ]
 
 
@@ -749,11 +539,6 @@ formatIpv6 =
                         |> expectAt
                             [ "format" ]
                             ( Decode.string, "ipv6" )
-            , test "decoder" <|
-                \() ->
-                    encode schema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult schema
             ]
 
 
@@ -771,11 +556,6 @@ formatUri =
                         |> expectAt
                             [ "format" ]
                             ( Decode.string, "uri" )
-            , test "decoder" <|
-                \() ->
-                    encode schema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult schema
             ]
 
 
@@ -793,9 +573,4 @@ formatCustom =
                         |> expectAt
                             [ "format" ]
                             ( Decode.string, "foo" )
-            , test "decoder" <|
-                \() ->
-                    encode schema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult schema
             ]

--- a/tests/specs/Tests.elm
+++ b/tests/specs/Tests.elm
@@ -34,6 +34,7 @@ spec =
         , formatIpv6
         , formatUri
         , formatCustom
+        , fallbackSchemaSpec
         ]
 
 
@@ -574,3 +575,15 @@ formatCustom =
                             [ "format" ]
                             ( Decode.string, "foo" )
             ]
+
+
+fallbackSchemaSpec : Test
+fallbackSchemaSpec =
+    describe "fallback schema"
+        [ test "fallback value is re-encoded" <|
+            \() ->
+                encode fallbackSchema
+                    |> expectAt
+                        [ "foo" ]
+                        ( Decode.string, "bar" )
+        ]

--- a/tests/specs/Tests.elm
+++ b/tests/specs/Tests.elm
@@ -23,6 +23,7 @@ spec =
         , numberEnumSchemaSpec
         , booleanSchemaSpec
         , nullSchemaSpec
+        , refSchemaSpec
         , oneOfSpec
         , anyOfSpec
         , allOfSpec
@@ -345,6 +346,30 @@ nullSchemaSpec =
                     |> expectAt
                         [ "type" ]
                         ( Decode.string, "null" )
+        ]
+
+
+refSchemaSpec : Test
+refSchemaSpec =
+    describe "null schema"
+        [ test "title property is set" <|
+            \() ->
+                encode refSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "ref schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode refSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "ref schema description" )
+        , test "has a ref" <|
+            \() ->
+                encode refSchema
+                    |> expectAt
+                        [ "$ref" ]
+                        ( Decode.string, "refurl" )
         ]
 
 


### PR DESCRIPTION
Progress:
- [x] Encode `lazy` schema's using `definitions` and `$ref`.
- [x] Decode JSON schema containing `definitions` using `lazy`.
- [x] Split decoder tests into their own test spec file.
- [x] Make `encodeValue` and `encodeString` equivalent again.