### PR TITLE
Validator

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -19,7 +19,8 @@
         "elm-community/shrink": "2.0.0 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
-        "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0"
+        "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0",
+        "norpan/elm-json-patch": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -15,6 +15,7 @@
     ],
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
+        "Skinney/murmur3": "2.0.4 <= v < 3.0.0",
         "elm-community/elm-test": "3.1.0 <= v < 4.0.0",
         "elm-community/maybe-extra": "3.1.0 <= v < 4.0.0",
         "elm-community/shrink": "2.0.0 <= v < 3.0.0",

--- a/elm-package.json
+++ b/elm-package.json
@@ -10,7 +10,8 @@
         "JsonSchema",
         "JsonSchema.Fuzz",
         "JsonSchema.Encoder",
-        "JsonSchema.Decoder"
+        "JsonSchema.Decoder",
+        "JsonSchema.Validator"
     ],
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",

--- a/src/JsonSchema.elm
+++ b/src/JsonSchema.elm
@@ -1,4 +1,4 @@
-module JsonSchema exposing (Schema, required, optional, title, description, enum, minimum, maximum, properties, items, minItems, maxItems, minLength, maxLength, pattern, format, dateTime, email, hostname, ipv4, ipv6, uri, customFormat, object, array, string, integer, number, boolean, null, oneOf, allOf, anyOf)
+module JsonSchema exposing (Schema, required, optional, title, description, enum, minimum, maximum, properties, items, minItems, maxItems, minLength, maxLength, pattern, format, dateTime, email, hostname, ipv4, ipv6, uri, customFormat, object, array, string, integer, number, boolean, null, oneOf, allOf, anyOf, lazy)
 
 {-| This library allows you to write your json schema files in elm, preventing inadvertent errors.
 
@@ -6,7 +6,7 @@ module JsonSchema exposing (Schema, required, optional, title, description, enum
 @docs Schema
 
 # Schema types
-@docs object, array, string, integer, number, boolean, null, oneOf, allOf, anyOf
+@docs object, array, string, integer, number, boolean, null, oneOf, allOf, anyOf, lazy
 
 # Keywords
 @docs title, description, enum, minimum, maximum, properties, items, minItems, maxItems, minLength, maxLength, pattern, format
@@ -361,3 +361,10 @@ anyOf : List BaseCombinatorSchemaProperty -> List Schema -> Schema
 anyOf props subSchemas =
     List.foldl (<|) { defaultCombinatorSchema | subSchemas = subSchemas } props
         |> AnyOf
+
+
+{-| Create a lazy type schema.
+-}
+lazy : (() -> Schema) -> Schema
+lazy thunk =
+    Lazy thunk

--- a/src/JsonSchema/Fuzz.elm
+++ b/src/JsonSchema/Fuzz.elm
@@ -47,6 +47,9 @@ schemaValue schema =
         Null _ ->
             nullFuzzer
 
+        Ref _ ->
+            Debug.crash "Fuzzing a ref schema is not supported"
+
         AnyOf anyOfSchema ->
             anyOfFuzzer anyOfSchema
 
@@ -57,6 +60,12 @@ schemaValue schema =
 
         AllOf allOfSchema ->
             Debug.crash "Fuzzing an allOf schema is currently not supported"
+
+        Lazy thunk ->
+            Debug.crash "Fuzzing a lazy schema is currently not supported"
+
+        Fallback value ->
+            Debug.crash "Fuzzing a fallback schema is not supported"
 
 
 objectFuzzer : ObjectSchema -> Fuzzer Value

--- a/src/JsonSchema/Model.elm
+++ b/src/JsonSchema/Model.elm
@@ -1,5 +1,7 @@
 module JsonSchema.Model exposing (..)
 
+import Json.Decode
+
 
 type Schema
     = Object ObjectSchema
@@ -9,9 +11,12 @@ type Schema
     | Number NumberSchema
     | Boolean (BaseSchema {})
     | Null (BaseSchema {})
+    | Ref RefSchema
     | OneOf BaseCombinatorSchema
     | AnyOf BaseCombinatorSchema
     | AllOf BaseCombinatorSchema
+    | Lazy (() -> Schema)
+    | Fallback Json.Decode.Value
 
 
 type alias BaseSchema extras =
@@ -72,6 +77,12 @@ type alias StringSchema =
             , format : Maybe StringFormat
             }
         )
+
+
+type alias RefSchema =
+    BaseSchema
+        { ref : String
+        }
 
 
 type alias BaseCombinatorSchema =

--- a/src/JsonSchema/Util.elm
+++ b/src/JsonSchema/Util.elm
@@ -1,0 +1,11 @@
+module JsonSchema.Util exposing (..)
+
+import JsonSchema.Model exposing (Schema)
+import Murmur3
+
+
+hash : Schema -> String
+hash schema =
+    toString schema
+        |> Murmur3.hashString 1234
+        |> toString

--- a/src/JsonSchema/Validator.elm
+++ b/src/JsonSchema/Validator.elm
@@ -1,0 +1,293 @@
+module JsonSchema.Validator exposing (validate, Error, RawError(..))
+
+import Array
+import JsonSchema.Model exposing (..)
+import Json.Decode exposing (..)
+import Json.Pointer exposing (Pointer)
+import Regex
+import Dict exposing (Dict)
+
+
+type alias Error =
+    ( Pointer, RawError )
+
+
+type RawError
+    = IsShorterThan Int
+    | IsLongerThan Int
+    | DoesNotMatchPattern String
+    | NotInEnumeration
+    | RequiredPropertyMissing String
+    | HasFewerItemsThan Int
+    | HasMoreItemsThan Int
+    | IsLessThan Float
+    | IsMoreThan Float
+    | TooManyMatches
+    | TooFewMatches
+    | DecodeError String
+
+
+validateObject : ObjectSchema -> Dict String Value -> List Error
+validateObject schema values =
+    List.concatMap (validateProperty values) schema.properties
+
+
+validateArray : ArraySchema -> Array.Array Value -> List Error
+validateArray schema values =
+    validateItems schema.items values
+        ++ validateMinItems schema.minItems values
+        ++ validateMaxItems schema.maxItems values
+
+
+validateItems : Maybe Schema -> Array.Array Value -> List Error
+validateItems items values =
+    case items of
+        Nothing ->
+            []
+
+        Just itemSchema ->
+            List.concat (List.indexedMap (\i v -> List.map (appendName (toString i)) (validate itemSchema v)) (Array.toList values))
+
+
+validateMinItems : Maybe Int -> Array.Array Value -> List Error
+validateMinItems int values =
+    case int of
+        Nothing ->
+            []
+
+        Just minItems ->
+            if Array.length values >= minItems then
+                []
+            else
+                [ ( [], HasFewerItemsThan minItems ) ]
+
+
+validateMaxItems : Maybe Int -> Array.Array Value -> List Error
+validateMaxItems int values =
+    case int of
+        Nothing ->
+            []
+
+        Just maxItems ->
+            if Array.length values <= maxItems then
+                []
+            else
+                [ ( [], HasMoreItemsThan maxItems ) ]
+
+
+validateString : StringSchema -> String -> List Error
+validateString schema string =
+    validateMinLength schema.minLength string
+        ++ validateMaxLength schema.maxLength string
+        ++ validatePattern schema.pattern string
+        ++ validateEnum schema.enum string
+
+
+validateMinLength : Maybe Int -> String -> List Error
+validateMinLength minLength string =
+    case minLength of
+        Nothing ->
+            []
+
+        Just minLength ->
+            if String.length string >= minLength then
+                []
+            else
+                [ ( [], IsShorterThan minLength ) ]
+
+
+validateMaxLength : Maybe Int -> String -> List Error
+validateMaxLength maxLength string =
+    case maxLength of
+        Nothing ->
+            []
+
+        Just maxLength ->
+            if String.length string <= maxLength then
+                []
+            else
+                [ ( [], IsLongerThan maxLength ) ]
+
+
+validatePattern : Maybe String -> String -> List Error
+validatePattern pattern string =
+    case pattern of
+        Nothing ->
+            []
+
+        Just pattern ->
+            if Regex.contains (Regex.regex pattern) string then
+                []
+            else
+                [ ( [], DoesNotMatchPattern pattern ) ]
+
+
+validateEnum : Maybe (List a) -> a -> List Error
+validateEnum enum a =
+    case enum of
+        Nothing ->
+            []
+
+        Just enum ->
+            if List.member a enum then
+                []
+            else
+                [ ( [], NotInEnumeration ) ]
+
+
+validateProperty : Dict String Value -> ObjectProperty -> List Error
+validateProperty values property =
+    case property of
+        Required name schema ->
+            case Dict.get name values of
+                Nothing ->
+                    [ ( [], RequiredPropertyMissing name ) ]
+
+                Just value ->
+                    List.map (appendName name) (validate schema value)
+
+        Optional name schema ->
+            case Dict.get name values of
+                Nothing ->
+                    []
+
+                Just value ->
+                    List.map (appendName name) (validate schema value)
+
+
+validateInteger : IntegerSchema -> Int -> List Error
+validateInteger schema integer =
+    validateEnum schema.enum integer
+        ++ validateMinimum (Maybe.map toFloat schema.minimum) (toFloat integer)
+        ++ validateMaximum (Maybe.map toFloat schema.maximum) (toFloat integer)
+
+
+validateNumber : NumberSchema -> Float -> List Error
+validateNumber schema number =
+    validateEnum schema.enum number
+        ++ validateMinimum schema.minimum number
+        ++ validateMaximum schema.maximum number
+
+
+validateMinimum : Maybe Float -> Float -> List Error
+validateMinimum minimum number =
+    case minimum of
+        Nothing ->
+            []
+
+        Just minimum ->
+            if number >= minimum then
+                []
+            else
+                [ ( [], IsLessThan minimum ) ]
+
+
+validateMaximum : Maybe Float -> Float -> List Error
+validateMaximum maximum number =
+    case maximum of
+        Nothing ->
+            []
+
+        Just maximum ->
+            if number <= maximum then
+                []
+            else
+                [ ( [], IsMoreThan maximum ) ]
+
+
+validate : Schema -> Value -> List Error
+validate schema v =
+    case schema of
+        Object objectSchema ->
+            decodeValue (dict value) v
+                |> Result.map (validateObject objectSchema)
+                |> getDecodeError
+
+        Array arraySchema ->
+            decodeValue (array value) v
+                |> Result.map (validateArray arraySchema)
+                |> getDecodeError
+
+        String stringSchema ->
+            decodeValue string v
+                |> Result.map (validateString stringSchema)
+                |> getDecodeError
+
+        Integer integerSchema ->
+            decodeValue int v
+                |> Result.map (validateInteger integerSchema)
+                |> getDecodeError
+
+        Number numberSchema ->
+            decodeValue float v
+                |> Result.map (validateNumber numberSchema)
+                |> getDecodeError
+
+        Boolean booleanSchema ->
+            decodeValue bool v
+                |> Result.map (always [])
+                |> getDecodeError
+
+        Null nullSchema ->
+            decodeValue (null []) v
+                |> getDecodeError
+
+        OneOf oneOfSchema ->
+            oneOfSchema.subSchemas
+                |> List.map (flip validate v)
+                |> List.filter (not << List.isEmpty)
+                |> List.length
+                |> (\i ->
+                        case i of
+                            0 ->
+                                [ ( [], TooManyMatches ) ]
+
+                            1 ->
+                                []
+
+                            _ ->
+                                [ ( [], TooFewMatches ) ]
+                   )
+
+        AnyOf anyOfSchema ->
+            anyOfSchema.subSchemas
+                |> List.map (flip validate v)
+                |> List.filter (List.isEmpty)
+                |> List.length
+                |> (\i ->
+                        case i of
+                            0 ->
+                                [ ( [], TooFewMatches ) ]
+
+                            _ ->
+                                []
+                   )
+
+        AllOf allOfSchema ->
+            allOfSchema.subSchemas
+                |> List.map (flip validate v)
+                |> List.filter (not << List.isEmpty)
+                |> List.length
+                |> (\i ->
+                        case i of
+                            0 ->
+                                []
+
+                            _ ->
+                                [ ( [], TooFewMatches ) ]
+                   )
+
+
+getDecodeError : Result String (List Error) -> List Error
+getDecodeError res =
+    case res of
+        Ok e ->
+            e
+
+        Err e ->
+            [ ( [], DecodeError e ) ]
+
+
+appendName : String -> Error -> Error
+appendName name ( pointer, error ) =
+    ( name :: pointer, error )

--- a/src/JsonSchema/Validator.elm
+++ b/src/JsonSchema/Validator.elm
@@ -1,18 +1,32 @@
-module JsonSchema.Validator exposing (validate, Error, RawError(..))
+module JsonSchema.Validator exposing (validate, Error, ErrorMessage(..))
+
+{-| Validating a JSON Schema.
+
+It does not yet validate the `format` keyword.
+
+@docs validate
+@docs Error, ErrorMessage
+
+-}
 
 import Array
 import JsonSchema.Model exposing (..)
 import Json.Decode exposing (..)
-import Json.Pointer exposing (Pointer)
+import Json.Pointer
 import Regex
 import Dict exposing (Dict)
 
 
+{-| The error type from a validation. It contains a JSON Pointer to where
+the validation error occured, and an error message
+-}
 type alias Error =
-    ( Pointer, RawError )
+    ( Json.Pointer.Pointer, ErrorMessage )
 
 
-type RawError
+{-| An error message from validation
+-}
+type ErrorMessage
     = IsShorterThan Int
     | IsLongerThan Int
     | DoesNotMatchPattern String
@@ -195,6 +209,13 @@ validateMaximum maximum number =
                 [ ( [], IsMoreThan maximum ) ]
 
 
+{-| Validate a JSON Value against a schema.
+
+If validation fails, a list of errors is returned, otherwise the list is empty.
+
+It does not yet validate the `format` keyword.
+
+-}
 validate : Schema -> Value -> List Error
 validate schema v =
     case schema of

--- a/src/JsonSchema/Validator.elm
+++ b/src/JsonSchema/Validator.elm
@@ -298,6 +298,15 @@ validate schema v =
                                 [ ( [], TooFewMatches ) ]
                    )
 
+        Ref _ ->
+            []
+
+        Lazy f ->
+            validate (f ()) v
+
+        Fallback _ ->
+            []
+
 
 getDecodeError : Result String (List Error) -> List Error
 getDecodeError res =

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -3,6 +3,8 @@ port module Main exposing (..)
 import Tests
 import Test
 import SchemaFuzzSpec
+import DecoderSpec
+import ValidatorSpec
 import Test.Runner.Node exposing (run, TestProgram)
 import Json.Encode exposing (Value)
 
@@ -11,6 +13,8 @@ main : TestProgram
 main =
     [ Tests.spec
     , SchemaFuzzSpec.spec
+    , DecoderSpec.spec
+    , ValidatorSpec.spec
     ]
         |> Test.concat
         |> run emit

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -19,6 +19,7 @@
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0",
+        "norpan/elm-json-patch": "1.0.0 <= v < 2.0.0",
         "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -12,6 +12,7 @@
     "native-modules": true,
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
+        "Skinney/murmur3": "2.0.4 <= v < 3.0.0",
         "elm-community/elm-test": "3.1.0 <= v < 4.0.0",
         "elm-community/json-extra": "2.0.0 <= v < 3.0.0",
         "elm-community/maybe-extra": "3.1.0 <= v < 4.0.0",

--- a/tests/specs/DecoderSpec.elm
+++ b/tests/specs/DecoderSpec.elm
@@ -1,0 +1,58 @@
+module DecoderSpec exposing (spec)
+
+import Expect exposing (pass)
+import Fixtures
+import Json.Decode as Decode
+import JsonSchema exposing (..)
+import JsonSchema.Decoder exposing (decoder)
+import JsonSchema.Encoder exposing (encode)
+import Test exposing (..)
+
+
+spec : Test
+spec =
+    describe "Decoder" <|
+        List.map testSchemaDecoder
+            [ Fixtures.objectSchema
+            , Fixtures.arraySchema
+            , Fixtures.stringSchema
+            , Fixtures.stringEnumSchema
+            , Fixtures.integerEnumSchema
+            , Fixtures.integerSchema
+            , Fixtures.numberSchema
+            , Fixtures.numberEnumSchema
+            , Fixtures.booleanSchema
+            , Fixtures.nullSchema
+            , Fixtures.refSchema
+            , Fixtures.oneOfSchema
+            , Fixtures.anyOfSchema
+            , Fixtures.allOfSchema
+            , Fixtures.fallbackSchema
+            , Fixtures.lazySchema
+            , string [ format dateTime ]
+            , string [ format email ]
+            , string [ format hostname ]
+            , string [ format ipv4 ]
+            , string [ format ipv6 ]
+            , string [ format uri ]
+            , string [ format (customFormat "foo") ]
+            ]
+
+
+{-| Test a decoder by taking a json schema string, decoding and then encoding it and expecting the same result as before.
+To make it easier to write this test, we generate the json schema string to test from an elm schema.
+This means that in practice, we test 1. encode -> 2. decode -> 3. encode, comparing the output from 1 and 3.
+-}
+testSchemaDecoder : Schema -> Test
+testSchemaDecoder schema =
+    let
+        jsonSchema : String
+        jsonSchema =
+            encode schema
+    in
+        test ("decoding work with schema: " ++ jsonSchema) <|
+            \_ ->
+                jsonSchema
+                    |> Decode.decodeString decoder
+                    |> Result.map encode
+                    |> Expect.equal (Ok jsonSchema)

--- a/tests/specs/Fixtures.elm
+++ b/tests/specs/Fixtures.elm
@@ -1,0 +1,151 @@
+module Fixtures exposing (..)
+
+import Json.Encode as Encode
+import JsonSchema exposing (..)
+import JsonSchema.Model
+
+
+objectSchema : Schema
+objectSchema =
+    object
+        [ title "object schema title"
+        , description "object schema description"
+        , properties
+            [ optional "firstName" <| string []
+            , required "lastName" <| string []
+            ]
+        ]
+
+
+arraySchema : Schema
+arraySchema =
+    array
+        [ title "array schema title"
+        , description "array schema description"
+        , items <| string []
+        , minItems 3
+        , maxItems 6
+        ]
+
+
+stringSchema : Schema
+stringSchema =
+    string
+        [ title "string schema title"
+        , description "string schema description"
+        , minLength 2
+        , maxLength 8
+        , pattern "^foo$"
+        , format dateTime
+        ]
+
+
+stringEnumSchema : Schema
+stringEnumSchema =
+    string
+        [ title "string schema title"
+        , enum [ "a", "b" ]
+        ]
+
+
+integerEnumSchema : Schema
+integerEnumSchema =
+    integer
+        [ title "integer schema title"
+        , enum [ 1, 2 ]
+        ]
+
+
+integerSchema : Schema
+integerSchema =
+    integer
+        [ title "integer schema title"
+        , description "integer schema description"
+        , minimum 2
+        , maximum 8
+        ]
+
+
+numberSchema : Schema
+numberSchema =
+    number
+        [ title "number schema title"
+        , description "number schema description"
+        , minimum 2.5
+        , maximum 8.3
+        ]
+
+
+numberEnumSchema : Schema
+numberEnumSchema =
+    number
+        [ title "number schema title"
+        , enum [ 1.2, 3.4 ]
+        ]
+
+
+booleanSchema : Schema
+booleanSchema =
+    boolean
+        [ title "boolean schema title"
+        , description "boolean schema description"
+        ]
+
+
+nullSchema : Schema
+nullSchema =
+    null
+        [ title "null schema title"
+        , description "null schema description"
+        ]
+
+
+refSchema : Schema
+refSchema =
+    JsonSchema.Model.Ref
+        { title = Just "ref schema title"
+        , description = Just "ref schema description"
+        , ref = "refurl"
+        }
+
+
+oneOfSchema : Schema
+oneOfSchema =
+    oneOf
+        [ title "oneOf schema title"
+        , description "oneOf schema description"
+        ]
+        [ integer [], string [] ]
+
+
+anyOfSchema : Schema
+anyOfSchema =
+    anyOf
+        [ title "anyOf schema title"
+        , description "anyOf schema description"
+        ]
+        [ integer [], string [] ]
+
+
+allOfSchema : Schema
+allOfSchema =
+    allOf
+        [ title "allOf schema title"
+        , description "allOf schema description"
+        ]
+        [ integer [], string [] ]
+
+
+lazySchema : Schema
+lazySchema =
+    array
+        [ items <| lazy (\_ -> lazySchema)
+        ]
+
+
+fallbackSchema : Schema
+fallbackSchema =
+    JsonSchema.Model.Fallback
+        (Encode.object
+            [ ( "foo", Encode.string "bar" ) ]
+        )

--- a/tests/specs/SchemaFuzzSpec.elm
+++ b/tests/specs/SchemaFuzzSpec.elm
@@ -1,11 +1,9 @@
 module SchemaFuzzSpec exposing (spec)
 
 import Expect exposing (pass)
-import Json.Encode as Encode
 import JsonSchema exposing (..)
-import JsonSchema.Encoder as Encoder
 import JsonSchema.Fuzz exposing (schemaValue)
-import Native.JsonSchema
+import JsonSchema.Validator
 import Test exposing (..)
 
 
@@ -42,22 +40,5 @@ testSchemaFuzzer : Schema -> Test
 testSchemaFuzzer schema =
     fuzz (schemaValue schema) ("fuzzer works with schema: " ++ (toString schema)) <|
         \value ->
-            let
-                jsonValue =
-                    Encode.encode 2 value
-
-                jsonSchema =
-                    Encoder.encode schema
-            in
-                Native.JsonSchema.validate jsonSchema jsonValue
-                    |> expectOk
-
-
-expectOk : Result String a -> Expect.Expectation
-expectOk result =
-    case result of
-        Ok _ ->
-            Expect.pass
-
-        Err message ->
-            Expect.fail message
+            JsonSchema.Validator.validate schema value
+                |> Expect.equal []

--- a/tests/specs/Tests.elm
+++ b/tests/specs/Tests.elm
@@ -1,13 +1,12 @@
 module Tests exposing (spec)
 
 import Expect
+import Fixtures exposing (..)
 import Helpers exposing (expectAt, lengthAt, expectEqualResult)
 import Json.Decode as Decode
-import Json.Encode as Encode
 import JsonSchema exposing (..)
 import JsonSchema.Encoder exposing (encode, encodeValue)
-import JsonSchema.Decoder exposing (decoder)
-import JsonSchema.Validator as Validator
+import JsonSchema.Util exposing (hash)
 import Test exposing (..)
 
 
@@ -24,9 +23,11 @@ spec =
         , numberEnumSchemaSpec
         , booleanSchemaSpec
         , nullSchemaSpec
+        , refSchemaSpec
         , oneOfSpec
         , anyOfSpec
         , allOfSpec
+        , lazySchemaSpec
         , formatDateTime
         , formatEmail
         , formatHostname
@@ -34,853 +35,451 @@ spec =
         , formatIpv6
         , formatUri
         , formatCustom
-        , deepValidation
+        , fallbackSchemaSpec
         ]
 
 
 objectSchemaSpec : Test
 objectSchemaSpec =
-    let
-        objectSchema : Schema
-        objectSchema =
-            object
-                [ title "object schema title"
-                , description "object schema description"
-                , properties
-                    [ optional "firstName" <| string []
-                    , required "lastName" <| string []
-                    ]
-                ]
-    in
-        describe "object schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode objectSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "object schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode objectSchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "object schema description" )
-            , test "has the right type" <|
-                \() ->
-                    encode objectSchema
-                        |> expectAt
-                            [ "type" ]
-                            ( Decode.string, "object" )
-            , test "adds the right properties to 'required'" <|
-                \() ->
-                    encode objectSchema
-                        |> expectAt
-                            [ "required", "0" ]
-                            ( Decode.string, "lastName" )
-            , test "array 'required' has correct length" <|
-                \() ->
-                    encode objectSchema
-                        |> lengthAt [ "required" ] 1
-            , test "first object property exists as nested schema" <|
-                \() ->
-                    encode objectSchema
-                        |> expectAt
-                            [ "properties", "firstName", "type" ]
-                            ( Decode.string, "string" )
-            , test "second object property exists as nested schema" <|
-                \() ->
-                    encode objectSchema
-                        |> expectAt
-                            [ "properties", "lastName", "type" ]
-                            ( Decode.string, "string" )
-            , test "decoder" <|
-                \() ->
-                    encode objectSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult objectSchema
-            , test "validate valid" <|
-                \() ->
-                    Encode.object [ ( "firstName", Encode.string "foo" ), ( "lastName", Encode.string "bar" ) ]
-                        |> Validator.validate objectSchema
-                        |> Expect.equal []
-            , test "validate valid optional field missing" <|
-                \() ->
-                    Encode.object [ ( "lastName", Encode.string "bar" ) ]
-                        |> Validator.validate objectSchema
-                        |> Expect.equal []
-            , test "validate valid additionalItems" <|
-                \() ->
-                    Encode.object [ ( "unknown", Encode.int 1 ), ( "firstName", Encode.string "foo" ), ( "lastName", Encode.string "bar" ) ]
-                        |> Validator.validate objectSchema
-                        |> Expect.equal []
-            , test "validate optional field wrong type" <|
-                \() ->
-                    Encode.object [ ( "firstName", Encode.int 1 ), ( "lastName", Encode.string "bar" ) ]
-                        |> Validator.validate objectSchema
-                        |> Expect.equal [ ( [ "firstName" ], Validator.DecodeError "Expecting a String but instead got: 1" ) ]
-            , test "validate required field missing" <|
-                \() ->
-                    Encode.object [ ( "firstName", Encode.string "bar" ) ]
-                        |> Validator.validate objectSchema
-                        |> Expect.equal [ ( [], Validator.RequiredPropertyMissing "lastName" ) ]
-            , test "validate multiple errors" <|
-                \() ->
-                    Encode.object [ ( "firstName", Encode.int 1 ) ]
-                        |> Validator.validate objectSchema
-                        |> Expect.equal
-                            [ ( [ "firstName" ], Validator.DecodeError "Expecting a String but instead got: 1" )
-                            , ( [], Validator.RequiredPropertyMissing "lastName" )
-                            ]
-            ]
+    describe "object schema"
+        [ test "title property is set" <|
+            \() ->
+                encode objectSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "object schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode objectSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "object schema description" )
+        , test "has the right type" <|
+            \() ->
+                encode objectSchema
+                    |> expectAt
+                        [ "type" ]
+                        ( Decode.string, "object" )
+        , test "adds the right properties to 'required'" <|
+            \() ->
+                encode objectSchema
+                    |> expectAt
+                        [ "required", "0" ]
+                        ( Decode.string, "lastName" )
+        , test "array 'required' has correct length" <|
+            \() ->
+                encode objectSchema
+                    |> lengthAt [ "required" ] 1
+        , test "first object property exists as nested schema" <|
+            \() ->
+                encode objectSchema
+                    |> expectAt
+                        [ "properties", "firstName", "type" ]
+                        ( Decode.string, "string" )
+        , test "second object property exists as nested schema" <|
+            \() ->
+                encode objectSchema
+                    |> expectAt
+                        [ "properties", "lastName", "type" ]
+                        ( Decode.string, "string" )
+        ]
 
 
 arraySchemaSpec : Test
 arraySchemaSpec =
-    let
-        arraySchema : Schema
-        arraySchema =
-            array
-                [ title "array schema title"
-                , description "array schema description"
-                , items <| string []
-                , minItems 3
-                , maxItems 6
-                ]
-    in
-        describe "array schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode arraySchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "array schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode arraySchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "array schema description" )
-            , test "has the right type" <|
-                \() ->
-                    encode arraySchema
-                        |> expectAt
-                            [ "type" ]
-                            ( Decode.string, "array" )
-            , test "items property contains nested schema" <|
-                \() ->
-                    encode arraySchema
-                        |> expectAt
-                            [ "items", "type" ]
-                            ( Decode.string, "string" )
-            , test "minItems property contains nested schema" <|
-                \() ->
-                    encode arraySchema
-                        |> expectAt
-                            [ "minItems" ]
-                            ( Decode.int, 3 )
-            , test "maxItems property contains nested schema" <|
-                \() ->
-                    encode arraySchema
-                        |> expectAt
-                            [ "maxItems" ]
-                            ( Decode.int, 6 )
-            , test "decoder" <|
-                \() ->
-                    encode arraySchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult arraySchema
-            , test "validate valid" <|
-                \() ->
-                    Encode.list [ Encode.string "foo", Encode.string "bar", Encode.string "baz" ]
-                        |> Validator.validate arraySchema
-                        |> Expect.equal []
-            , test "validate too short" <|
-                \() ->
-                    Encode.list [ Encode.string "foo", Encode.string "bar" ]
-                        |> Validator.validate arraySchema
-                        |> Expect.equal [ ( [], Validator.HasFewerItemsThan 3 ) ]
-            , test "validate too long" <|
-                \() ->
-                    Encode.list
-                        [ Encode.string "foo"
-                        , Encode.string "bar"
-                        , Encode.string "baz"
-                        , Encode.string "foo"
-                        , Encode.string "bar"
-                        , Encode.string "baz"
-                        , Encode.string "foo"
-                        ]
-                        |> Validator.validate arraySchema
-                        |> Expect.equal [ ( [], Validator.HasMoreItemsThan 6 ) ]
-            , test "validate wrong item type" <|
-                \() ->
-                    Encode.list
-                        [ Encode.string "foo"
-                        , Encode.string "bar"
-                        , Encode.string "baz"
-                        , Encode.int 1
-                        , Encode.string "bar"
-                        , Encode.string "baz"
-                        ]
-                        |> Validator.validate arraySchema
-                        |> Expect.equal
-                            [ ( [ "3" ]
-                              , Validator.DecodeError "Expecting a String but instead got: 1"
-                              )
-                            ]
-            , test "validate multiple errors" <|
-                \() ->
-                    Encode.list
-                        [ Encode.string "foo"
-                        , Encode.int 1
-                        ]
-                        |> Validator.validate arraySchema
-                        |> Expect.equal
-                            [ ( [ "1" ]
-                              , Validator.DecodeError "Expecting a String but instead got: 1"
-                              )
-                            , ( [], Validator.HasFewerItemsThan 3 )
-                            ]
-            ]
+    describe "array schema"
+        [ test "title property is set" <|
+            \() ->
+                encode arraySchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "array schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode arraySchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "array schema description" )
+        , test "has the right type" <|
+            \() ->
+                encode arraySchema
+                    |> expectAt
+                        [ "type" ]
+                        ( Decode.string, "array" )
+        , test "items property contains nested schema" <|
+            \() ->
+                encode arraySchema
+                    |> expectAt
+                        [ "items", "type" ]
+                        ( Decode.string, "string" )
+        , test "minItems property contains nested schema" <|
+            \() ->
+                encode arraySchema
+                    |> expectAt
+                        [ "minItems" ]
+                        ( Decode.int, 3 )
+        , test "maxItems property contains nested schema" <|
+            \() ->
+                encode arraySchema
+                    |> expectAt
+                        [ "maxItems" ]
+                        ( Decode.int, 6 )
+        ]
 
 
 stringSchemaSpec : Test
 stringSchemaSpec =
-    let
-        stringSchema : Schema
-        stringSchema =
-            string
-                [ title "string schema title"
-                , description "string schema description"
-                , minLength 2
-                , maxLength 8
-                , pattern "f"
-                , format dateTime
-                ]
-    in
-        describe "string schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode stringSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "string schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode stringSchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "string schema description" )
-            , test "has the right type" <|
-                \() ->
-                    encode stringSchema
-                        |> expectAt
-                            [ "type" ]
-                            ( Decode.string, "string" )
-            , test "minLength property is set" <|
-                \() ->
-                    encode stringSchema
-                        |> expectAt
-                            [ "minLength" ]
-                            ( Decode.int, 2 )
-            , test "maxLength property is set" <|
-                \() ->
-                    encode stringSchema
-                        |> expectAt
-                            [ "maxLength" ]
-                            ( Decode.int, 8 )
-            , test "pattern property is set" <|
-                \() ->
-                    encode stringSchema
-                        |> expectAt
-                            [ "pattern" ]
-                            ( Decode.string, "f" )
-            , test "format property is set" <|
-                \() ->
-                    encode stringSchema
-                        |> expectAt
-                            [ "format" ]
-                            ( Decode.string, "date-time" )
-            , test "decoder" <|
-                \() ->
-                    encode stringSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult stringSchema
-            , test "validate valid" <|
-                \() ->
-                    Encode.string "foo"
-                        |> Validator.validate stringSchema
-                        |> Expect.equal []
-            , test "validate wrong pattern" <|
-                \() ->
-                    Encode.string "goo"
-                        |> Validator.validate stringSchema
-                        |> Expect.equal [ ( [], Validator.DoesNotMatchPattern "f" ) ]
-            , test "validate too short" <|
-                \() ->
-                    Encode.string "f"
-                        |> Validator.validate stringSchema
-                        |> Expect.equal [ ( [], Validator.IsShorterThan 2 ) ]
-            , test "validate too long" <|
-                \() ->
-                    Encode.string "foooooooo"
-                        |> Validator.validate stringSchema
-                        |> Expect.equal [ ( [], Validator.IsLongerThan 8 ) ]
-            , test "validate multiple errors" <|
-                \() ->
-                    Encode.string "goooooooo"
-                        |> Validator.validate stringSchema
-                        |> Expect.equal [ ( [], Validator.IsLongerThan 8 ), ( [], Validator.DoesNotMatchPattern "f" ) ]
-            ]
+    describe "string schema"
+        [ test "title property is set" <|
+            \() ->
+                encode stringSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "string schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode stringSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "string schema description" )
+        , test "has the right type" <|
+            \() ->
+                encode stringSchema
+                    |> expectAt
+                        [ "type" ]
+                        ( Decode.string, "string" )
+        , test "minLength property is set" <|
+            \() ->
+                encode stringSchema
+                    |> expectAt
+                        [ "minLength" ]
+                        ( Decode.int, 2 )
+        , test "maxLength property is set" <|
+            \() ->
+                encode stringSchema
+                    |> expectAt
+                        [ "maxLength" ]
+                        ( Decode.int, 8 )
+        , test "pattern property is set" <|
+            \() ->
+                encode stringSchema
+                    |> expectAt
+                        [ "pattern" ]
+                        ( Decode.string, "^foo$" )
+        , test "format property is set" <|
+            \() ->
+                encode stringSchema
+                    |> expectAt
+                        [ "format" ]
+                        ( Decode.string, "date-time" )
+        ]
 
 
 stringEnumSchemaSpec : Test
 stringEnumSchemaSpec =
-    let
-        stringEnumSchema : Schema
-        stringEnumSchema =
-            string
-                [ title "string schema title"
-                , enum [ "a", "b" ]
-                ]
-    in
-        describe "string enum schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode stringEnumSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "string schema title" )
-            , test "enum property is set" <|
-                \() ->
-                    encode stringEnumSchema
-                        |> expectAt
-                            [ "enum" ]
-                            ( Decode.list Decode.string, [ "a", "b" ] )
-            , test "decoder" <|
-                \() ->
-                    encode stringEnumSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult stringEnumSchema
-            , test "validate valid 1" <|
-                \() ->
-                    Encode.string "a"
-                        |> Validator.validate stringEnumSchema
-                        |> Expect.equal []
-            , test "validate valid 2" <|
-                \() ->
-                    Encode.string "b"
-                        |> Validator.validate stringEnumSchema
-                        |> Expect.equal []
-            , test "validate invalid" <|
-                \() ->
-                    Encode.string "c"
-                        |> Validator.validate stringEnumSchema
-                        |> Expect.equal [ ( [], Validator.NotInEnumeration ) ]
-            ]
+    describe "string enum schema"
+        [ test "title property is set" <|
+            \() ->
+                encode stringEnumSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "string schema title" )
+        , test "enum property is set" <|
+            \() ->
+                encode stringEnumSchema
+                    |> expectAt
+                        [ "enum" ]
+                        ( Decode.list Decode.string, [ "a", "b" ] )
+        ]
 
 
 integerEnumSchemaSpec : Test
 integerEnumSchemaSpec =
-    let
-        integerEnumSchema : Schema
-        integerEnumSchema =
-            integer
-                [ title "integer schema title"
-                , enum [ 1, 2 ]
-                ]
-    in
-        describe "integer enum schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode integerEnumSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "integer schema title" )
-            , test "enum property is set" <|
-                \() ->
-                    encode integerEnumSchema
-                        |> expectAt
-                            [ "enum" ]
-                            ( Decode.list Decode.int, [ 1, 2 ] )
-            , test "decoder" <|
-                \() ->
-                    encode integerEnumSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult integerEnumSchema
-            , test "validate valid 1" <|
-                \() ->
-                    Encode.int 1
-                        |> Validator.validate integerEnumSchema
-                        |> Expect.equal []
-            , test "validate valid 2" <|
-                \() ->
-                    Encode.int 2
-                        |> Validator.validate integerEnumSchema
-                        |> Expect.equal []
-            , test "validate invalid" <|
-                \() ->
-                    Encode.int 3
-                        |> Validator.validate integerEnumSchema
-                        |> Expect.equal [ ( [], Validator.NotInEnumeration ) ]
-            ]
+    describe "integer enum schema"
+        [ test "title property is set" <|
+            \() ->
+                encode integerEnumSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "integer schema title" )
+        , test "enum property is set" <|
+            \() ->
+                encode integerEnumSchema
+                    |> expectAt
+                        [ "enum" ]
+                        ( Decode.list Decode.int, [ 1, 2 ] )
+        ]
 
 
 integerSchemaSpec : Test
 integerSchemaSpec =
-    let
-        integerSchema : Schema
-        integerSchema =
-            integer
-                [ title "integer schema title"
-                , description "integer schema description"
-                , minimum 2
-                , maximum 8
-                ]
-    in
-        describe "integer schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode integerSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "integer schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode integerSchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "integer schema description" )
-            , test "has the right type" <|
-                \() ->
-                    encode integerSchema
-                        |> expectAt
-                            [ "type" ]
-                            ( Decode.string, "integer" )
-            , test "minimum property is set" <|
-                \() ->
-                    encode integerSchema
-                        |> expectAt
-                            [ "minimum" ]
-                            ( Decode.int, 2 )
-            , test "maximum property is set" <|
-                \() ->
-                    encode integerSchema
-                        |> expectAt
-                            [ "maximum" ]
-                            ( Decode.int, 8 )
-            , test "decoder" <|
-                \() ->
-                    encode integerSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult integerSchema
-            , test "validate valid" <|
-                \() ->
-                    Encode.int 4
-                        |> Validator.validate integerSchema
-                        |> Expect.equal []
-            , test "validate too small" <|
-                \() ->
-                    Encode.int 1
-                        |> Validator.validate integerSchema
-                        |> Expect.equal [ ( [], Validator.IsLessThan 2 ) ]
-            , test "validate too large" <|
-                \() ->
-                    Encode.int 9
-                        |> Validator.validate integerSchema
-                        |> Expect.equal [ ( [], Validator.IsMoreThan 8 ) ]
-            ]
+    describe "integer schema"
+        [ test "title property is set" <|
+            \() ->
+                encode integerSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "integer schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode integerSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "integer schema description" )
+        , test "has the right type" <|
+            \() ->
+                encode integerSchema
+                    |> expectAt
+                        [ "type" ]
+                        ( Decode.string, "integer" )
+        , test "minimum property is set" <|
+            \() ->
+                encode integerSchema
+                    |> expectAt
+                        [ "minimum" ]
+                        ( Decode.int, 2 )
+        , test "maximum property is set" <|
+            \() ->
+                encode integerSchema
+                    |> expectAt
+                        [ "maximum" ]
+                        ( Decode.int, 8 )
+        ]
 
 
 numberSchemaSpec : Test
 numberSchemaSpec =
-    let
-        numberSchema : Schema
-        numberSchema =
-            number
-                [ title "number schema title"
-                , description "number schema description"
-                , minimum 2.5
-                , maximum 8.3
-                ]
-    in
-        describe "number schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode numberSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "number schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode numberSchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "number schema description" )
-            , test "has the right type" <|
-                \() ->
-                    encode numberSchema
-                        |> expectAt
-                            [ "type" ]
-                            ( Decode.string, "number" )
-            , test "minimum property is set" <|
-                \() ->
-                    encode numberSchema
-                        |> expectAt
-                            [ "minimum" ]
-                            ( Decode.float, 2.5 )
-            , test "maximum property is set" <|
-                \() ->
-                    encode numberSchema
-                        |> expectAt
-                            [ "maximum" ]
-                            ( Decode.float, 8.3 )
-            , test "decoder" <|
-                \() ->
-                    encode numberSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult numberSchema
-            , test "validate valid" <|
-                \() ->
-                    Encode.float 4
-                        |> Validator.validate numberSchema
-                        |> Expect.equal []
-            , test "validate too small" <|
-                \() ->
-                    Encode.float 2.4
-                        |> Validator.validate numberSchema
-                        |> Expect.equal [ ( [], Validator.IsLessThan 2.5 ) ]
-            , test "validate too large" <|
-                \() ->
-                    Encode.float 8.4
-                        |> Validator.validate numberSchema
-                        |> Expect.equal [ ( [], Validator.IsMoreThan 8.3 ) ]
-            ]
+    describe "number schema"
+        [ test "title property is set" <|
+            \() ->
+                encode numberSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "number schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode numberSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "number schema description" )
+        , test "has the right type" <|
+            \() ->
+                encode numberSchema
+                    |> expectAt
+                        [ "type" ]
+                        ( Decode.string, "number" )
+        , test "minimum property is set" <|
+            \() ->
+                encode numberSchema
+                    |> expectAt
+                        [ "minimum" ]
+                        ( Decode.float, 2.5 )
+        , test "maximum property is set" <|
+            \() ->
+                encode numberSchema
+                    |> expectAt
+                        [ "maximum" ]
+                        ( Decode.float, 8.3 )
+        ]
 
 
 numberEnumSchemaSpec : Test
 numberEnumSchemaSpec =
-    let
-        numberEnumSchema : Schema
-        numberEnumSchema =
-            number
-                [ title "number schema title"
-                , enum [ 1.2, 3.4 ]
-                ]
-    in
-        describe "number schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode numberEnumSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "number schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode numberEnumSchema
-                        |> expectAt
-                            [ "enum" ]
-                            ( Decode.list Decode.float, [ 1.2, 3.4 ] )
-            , test "decoder" <|
-                \() ->
-                    encode numberEnumSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult numberEnumSchema
-            , test "validate valid 1" <|
-                \() ->
-                    Encode.float 1.2
-                        |> Validator.validate numberEnumSchema
-                        |> Expect.equal []
-            , test "validate valid 2" <|
-                \() ->
-                    Encode.float 3.4
-                        |> Validator.validate numberEnumSchema
-                        |> Expect.equal []
-            , test "validate invalid" <|
-                \() ->
-                    Encode.float 2.3
-                        |> Validator.validate numberEnumSchema
-                        |> Expect.equal [ ( [], Validator.NotInEnumeration ) ]
-            ]
+    describe "number schema"
+        [ test "title property is set" <|
+            \() ->
+                encode numberEnumSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "number schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode numberEnumSchema
+                    |> expectAt
+                        [ "enum" ]
+                        ( Decode.list Decode.float, [ 1.2, 3.4 ] )
+        ]
 
 
 booleanSchemaSpec : Test
 booleanSchemaSpec =
-    let
-        booleanSchema : Schema
-        booleanSchema =
-            boolean
-                [ title "boolean schema title"
-                , description "boolean schema description"
-                ]
-    in
-        describe "boolean schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode booleanSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "boolean schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode booleanSchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "boolean schema description" )
-            , test "has the right type" <|
-                \() ->
-                    encode booleanSchema
-                        |> expectAt
-                            [ "type" ]
-                            ( Decode.string, "boolean" )
-            , test "decoder" <|
-                \() ->
-                    encode booleanSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult booleanSchema
-            , test "validate valid" <|
-                \() ->
-                    Encode.bool True
-                        |> Validator.validate booleanSchema
-                        |> Expect.equal []
-            , test "validate invalid type" <|
-                \() ->
-                    Encode.int 1
-                        |> Validator.validate booleanSchema
-                        |> Expect.equal [ ( [], Validator.DecodeError "Expecting a Bool but instead got: 1" ) ]
-            ]
+    describe "boolean schema"
+        [ test "title property is set" <|
+            \() ->
+                encode booleanSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "boolean schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode booleanSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "boolean schema description" )
+        , test "has the right type" <|
+            \() ->
+                encode booleanSchema
+                    |> expectAt
+                        [ "type" ]
+                        ( Decode.string, "boolean" )
+        ]
 
 
 nullSchemaSpec : Test
 nullSchemaSpec =
-    let
-        nullSchema : Schema
-        nullSchema =
-            null
-                [ title "null schema title"
-                , description "null schema description"
-                ]
-    in
-        describe "null schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode nullSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "null schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode nullSchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "null schema description" )
-            , test "has the right type" <|
-                \() ->
-                    encode nullSchema
-                        |> expectAt
-                            [ "type" ]
-                            ( Decode.string, "null" )
-            , test "decoder" <|
-                \() ->
-                    encode nullSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult nullSchema
-            , test "validate valid" <|
-                \() ->
-                    Encode.null
-                        |> Validator.validate nullSchema
-                        |> Expect.equal []
-            , test "validate invalid type" <|
-                \() ->
-                    Encode.int 1
-                        |> Validator.validate nullSchema
-                        |> Expect.equal [ ( [], Validator.DecodeError "Expecting null but instead got: 1" ) ]
-            ]
+    describe "null schema"
+        [ test "title property is set" <|
+            \() ->
+                encode nullSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "null schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode nullSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "null schema description" )
+        , test "has the right type" <|
+            \() ->
+                encode nullSchema
+                    |> expectAt
+                        [ "type" ]
+                        ( Decode.string, "null" )
+        ]
+
+
+refSchemaSpec : Test
+refSchemaSpec =
+    describe "null schema"
+        [ test "title property is set" <|
+            \() ->
+                encode refSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "ref schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode refSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "ref schema description" )
+        , test "has a ref" <|
+            \() ->
+                encode refSchema
+                    |> expectAt
+                        [ "$ref" ]
+                        ( Decode.string, "refurl" )
+        ]
 
 
 oneOfSpec : Test
 oneOfSpec =
-    let
-        oneOfSchema =
-            oneOf
-                [ title "oneOf schema title"
-                , description "oneOf schema description"
-                ]
-                [ string [ pattern "a" ], string [ pattern "b" ] ]
-    in
-        describe "oneOf schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode oneOfSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "oneOf schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode oneOfSchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "oneOf schema description" )
-            , test "subSchemas are set" <|
-                \() ->
-                    encode oneOfSchema
-                        |> Expect.all
-                            [ expectAt
-                                [ "oneOf", "0", "type" ]
-                                ( Decode.string, "string" )
-                            , expectAt
-                                [ "oneOf", "1", "type" ]
-                                ( Decode.string, "string" )
-                            ]
-            , test "decoder" <|
-                \() ->
-                    encode oneOfSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult oneOfSchema
-            , test "validate valid 1" <|
-                \() ->
-                    Encode.string "a"
-                        |> Validator.validate oneOfSchema
-                        |> Expect.equal []
-            , test "validate valid 2" <|
-                \() ->
-                    Encode.string "b"
-                        |> Validator.validate oneOfSchema
-                        |> Expect.equal []
-            , test "validate no match" <|
-                \() ->
-                    Encode.string "c"
-                        |> Validator.validate oneOfSchema
-                        |> Expect.equal [ ( [], Validator.TooFewMatches ) ]
-            , test "validate too many" <|
-                \() ->
-                    Encode.string "ab"
-                        |> Validator.validate oneOfSchema
-                        |> Expect.equal [ ( [], Validator.TooManyMatches ) ]
-            ]
+    describe "oneOf schema"
+        [ test "title property is set" <|
+            \() ->
+                encode oneOfSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "oneOf schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode oneOfSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "oneOf schema description" )
+        , test "subSchemas are set" <|
+            \() ->
+                encode oneOfSchema
+                    |> Expect.all
+                        [ expectAt
+                            [ "oneOf", "0", "type" ]
+                            ( Decode.string, "integer" )
+                        , expectAt
+                            [ "oneOf", "1", "type" ]
+                            ( Decode.string, "string" )
+                        ]
+        ]
 
 
 anyOfSpec : Test
 anyOfSpec =
-    let
-        anyOfSchema =
-            anyOf
-                [ title "anyOf schema title"
-                , description "anyOf schema description"
-                ]
-                [ string [ pattern "a" ], string [ pattern "b" ] ]
-    in
-        describe "anyOf schema"
-            [ test "title property is set" <|
-                \() ->
-                    encode anyOfSchema
-                        |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "anyOf schema title" )
-            , test "description property is set" <|
-                \() ->
-                    encode anyOfSchema
-                        |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "anyOf schema description" )
-            , test "subSchemas are set" <|
-                \() ->
-                    encode anyOfSchema
-                        |> Expect.all
-                            [ expectAt
-                                [ "anyOf", "0", "type" ]
-                                ( Decode.string, "string" )
-                            , expectAt
-                                [ "anyOf", "1", "type" ]
-                                ( Decode.string, "string" )
-                            ]
-            , test "decoder" <|
-                \() ->
-                    encode anyOfSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult anyOfSchema
-            , test "validate valid 1" <|
-                \() ->
-                    Encode.string "a"
-                        |> Validator.validate anyOfSchema
-                        |> Expect.equal []
-            , test "validate valid 2" <|
-                \() ->
-                    Encode.string "b"
-                        |> Validator.validate anyOfSchema
-                        |> Expect.equal []
-            , test "validate valid 3" <|
-                \() ->
-                    Encode.string "ab"
-                        |> Validator.validate anyOfSchema
-                        |> Expect.equal []
-            , test "validate no match" <|
-                \() ->
-                    Encode.string "c"
-                        |> Validator.validate anyOfSchema
-                        |> Expect.equal [ ( [], Validator.TooFewMatches ) ]
-            ]
+    describe "anyOf schema"
+        [ test "title property is set" <|
+            \() ->
+                encode anyOfSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "anyOf schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode anyOfSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "anyOf schema description" )
+        , test "subSchemas are set" <|
+            \() ->
+                encode anyOfSchema
+                    |> Expect.all
+                        [ expectAt
+                            [ "anyOf", "0", "type" ]
+                            ( Decode.string, "integer" )
+                        , expectAt
+                            [ "anyOf", "1", "type" ]
+                            ( Decode.string, "string" )
+                        ]
+        ]
 
 
 allOfSpec : Test
 allOfSpec =
+    describe "allOf schema"
+        [ test "title property is set" <|
+            \() ->
+                encode allOfSchema
+                    |> expectAt
+                        [ "title" ]
+                        ( Decode.string, "allOf schema title" )
+        , test "description property is set" <|
+            \() ->
+                encode allOfSchema
+                    |> expectAt
+                        [ "description" ]
+                        ( Decode.string, "allOf schema description" )
+        , test "subSchemas are set" <|
+            \() ->
+                encode allOfSchema
+                    |> Expect.all
+                        [ expectAt
+                            [ "allOf", "0", "type" ]
+                            ( Decode.string, "integer" )
+                        , expectAt
+                            [ "allOf", "1", "type" ]
+                            ( Decode.string, "string" )
+                        ]
+        ]
+
+
+lazySchemaSpec : Test
+lazySchemaSpec =
     let
-        allOfSchema =
-            allOf
-                [ title "allOf schema title"
-                , description "allOf schema description"
-                ]
-                [ string [ pattern "a" ], string [ pattern "b" ] ]
+        key : String
+        key =
+            hash lazySchema
     in
-        describe "allOf schema"
-            [ test "title property is set" <|
+        describe "lazy"
+            [ test "is turned into a ref" <|
                 \() ->
-                    encode allOfSchema
+                    encode lazySchema
                         |> expectAt
-                            [ "title" ]
-                            ( Decode.string, "allOf schema title" )
-            , test "description property is set" <|
+                            [ "items", "$ref" ]
+                            ( Decode.string, "#/definitions/" ++ key )
+            , test "is turned into a ref" <|
                 \() ->
-                    encode allOfSchema
+                    encode lazySchema
                         |> expectAt
-                            [ "description" ]
-                            ( Decode.string, "allOf schema description" )
-            , test "subSchemas are set" <|
-                \() ->
-                    encode allOfSchema
-                        |> Expect.all
-                            [ expectAt
-                                [ "allOf", "0", "type" ]
-                                ( Decode.string, "string" )
-                            , expectAt
-                                [ "allOf", "1", "type" ]
-                                ( Decode.string, "string" )
-                            ]
-            , test "decoder" <|
-                \() ->
-                    encode allOfSchema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult allOfSchema
-            , test "validate valid" <|
-                \() ->
-                    Encode.string "ab"
-                        |> Validator.validate allOfSchema
-                        |> Expect.equal []
-            , test "validate invalid 1" <|
-                \() ->
-                    Encode.string "a"
-                        |> Validator.validate allOfSchema
-                        |> Expect.equal [ ( [], Validator.TooFewMatches ) ]
-            , test "validate invalid 2" <|
-                \() ->
-                    Encode.string "b"
-                        |> Validator.validate allOfSchema
-                        |> Expect.equal [ ( [], Validator.TooFewMatches ) ]
-            , test "validate invalid 3" <|
-                \() ->
-                    Encode.string "c"
-                        |> Validator.validate allOfSchema
-                        |> Expect.equal [ ( [], Validator.TooFewMatches ) ]
+                            [ "definitions", key, "type" ]
+                            ( Decode.string, "array" )
             ]
 
 
@@ -898,11 +497,6 @@ formatDateTime =
                         |> expectAt
                             [ "format" ]
                             ( Decode.string, "date-time" )
-            , test "decoder" <|
-                \() ->
-                    encode schema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult schema
             ]
 
 
@@ -920,11 +514,6 @@ formatEmail =
                         |> expectAt
                             [ "format" ]
                             ( Decode.string, "email" )
-            , test "decoder" <|
-                \() ->
-                    encode schema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult schema
             ]
 
 
@@ -942,11 +531,6 @@ formatHostname =
                         |> expectAt
                             [ "format" ]
                             ( Decode.string, "hostname" )
-            , test "decoder" <|
-                \() ->
-                    encode schema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult schema
             ]
 
 
@@ -964,11 +548,6 @@ formatIpv4 =
                         |> expectAt
                             [ "format" ]
                             ( Decode.string, "ipv4" )
-            , test "decoder" <|
-                \() ->
-                    encode schema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult schema
             ]
 
 
@@ -986,11 +565,6 @@ formatIpv6 =
                         |> expectAt
                             [ "format" ]
                             ( Decode.string, "ipv6" )
-            , test "decoder" <|
-                \() ->
-                    encode schema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult schema
             ]
 
 
@@ -1008,11 +582,6 @@ formatUri =
                         |> expectAt
                             [ "format" ]
                             ( Decode.string, "uri" )
-            , test "decoder" <|
-                \() ->
-                    encode schema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult schema
             ]
 
 
@@ -1030,56 +599,16 @@ formatCustom =
                         |> expectAt
                             [ "format" ]
                             ( Decode.string, "foo" )
-            , test "decoder" <|
-                \() ->
-                    encode schema
-                        |> Decode.decodeString decoder
-                        |> expectEqualResult schema
             ]
 
 
-deepValidation : Test
-deepValidation =
-    let
-        deepSchema =
-            object
-                [ properties
-                    [ required "field"
-                        (array
-                            [ items
-                                (string
-                                    [ pattern "a" ]
-                                )
-                            ]
-                        )
-                    ]
-                ]
-    in
-        describe "deep validation"
-            [ test "validate valid" <|
-                \() ->
-                    Encode.object
-                        [ ( "field"
-                          , Encode.list
-                                [ Encode.string "a" ]
-                          )
-                        ]
-                        |> Validator.validate deepSchema
-                        |> Expect.equal []
-            , test "validate invalid 1" <|
-                \() ->
-                    Encode.object
-                        [ ( "field"
-                          , Encode.list
-                                [ Encode.string "b" ]
-                          )
-                        ]
-                        |> Validator.validate deepSchema
-                        |> Expect.equal
-                            [ ( [ "field"
-                                , "0"
-                                ]
-                              , Validator.DoesNotMatchPattern "a"
-                              )
-                            ]
-            ]
+fallbackSchemaSpec : Test
+fallbackSchemaSpec =
+    describe "fallback schema"
+        [ test "fallback value is re-encoded" <|
+            \() ->
+                encode fallbackSchema
+                    |> expectAt
+                        [ "foo" ]
+                        ( Decode.string, "bar" )
+        ]

--- a/tests/specs/ValidatorSpec.elm
+++ b/tests/specs/ValidatorSpec.elm
@@ -1,0 +1,519 @@
+module ValidatorSpec exposing (spec)
+
+import Expect
+import Json.Encode as Encode
+import JsonSchema exposing (..)
+import JsonSchema.Validator as Validator
+import Test exposing (..)
+
+
+spec : Test
+spec =
+    describe "JsonSchema"
+        [ objectSchemaSpec
+        , arraySchemaSpec
+        , stringSchemaSpec
+        , stringEnumSchemaSpec
+        , integerSchemaSpec
+        , integerEnumSchemaSpec
+        , numberSchemaSpec
+        , numberEnumSchemaSpec
+        , booleanSchemaSpec
+        , nullSchemaSpec
+        , oneOfSpec
+        , anyOfSpec
+        , allOfSpec
+        , lazySpec
+        ]
+
+
+objectSchemaSpec : Test
+objectSchemaSpec =
+    let
+        objectSchema : Schema
+        objectSchema =
+            object
+                [ title "object schema title"
+                , description "object schema description"
+                , properties
+                    [ optional "firstName" <| string []
+                    , required "lastName" <| string []
+                    ]
+                ]
+    in
+        describe "object schema"
+            [ test "validate valid" <|
+                \() ->
+                    Encode.object [ ( "firstName", Encode.string "foo" ), ( "lastName", Encode.string "bar" ) ]
+                        |> Validator.validate objectSchema
+                        |> Expect.equal []
+            , test "validate valid optional field missing" <|
+                \() ->
+                    Encode.object [ ( "lastName", Encode.string "bar" ) ]
+                        |> Validator.validate objectSchema
+                        |> Expect.equal []
+            , test "validate valid additionalItems" <|
+                \() ->
+                    Encode.object [ ( "unknown", Encode.int 1 ), ( "firstName", Encode.string "foo" ), ( "lastName", Encode.string "bar" ) ]
+                        |> Validator.validate objectSchema
+                        |> Expect.equal []
+            , test "validate optional field wrong type" <|
+                \() ->
+                    Encode.object [ ( "firstName", Encode.int 1 ), ( "lastName", Encode.string "bar" ) ]
+                        |> Validator.validate objectSchema
+                        |> Expect.equal [ ( [ "firstName" ], Validator.DecodeError "Expecting a String but instead got: 1" ) ]
+            , test "validate required field missing" <|
+                \() ->
+                    Encode.object [ ( "firstName", Encode.string "bar" ) ]
+                        |> Validator.validate objectSchema
+                        |> Expect.equal [ ( [], Validator.RequiredPropertyMissing "lastName" ) ]
+            , test "validate multiple errors" <|
+                \() ->
+                    Encode.object [ ( "firstName", Encode.int 1 ) ]
+                        |> Validator.validate objectSchema
+                        |> Expect.equal
+                            [ ( [ "firstName" ], Validator.DecodeError "Expecting a String but instead got: 1" )
+                            , ( [], Validator.RequiredPropertyMissing "lastName" )
+                            ]
+            ]
+
+
+arraySchemaSpec : Test
+arraySchemaSpec =
+    let
+        arraySchema : Schema
+        arraySchema =
+            array
+                [ title "array schema title"
+                , description "array schema description"
+                , items <| string []
+                , minItems 3
+                , maxItems 6
+                ]
+    in
+        describe "array schema"
+            [ test "validate valid" <|
+                \() ->
+                    Encode.list [ Encode.string "foo", Encode.string "bar", Encode.string "baz" ]
+                        |> Validator.validate arraySchema
+                        |> Expect.equal []
+            , test "validate too short" <|
+                \() ->
+                    Encode.list [ Encode.string "foo", Encode.string "bar" ]
+                        |> Validator.validate arraySchema
+                        |> Expect.equal [ ( [], Validator.HasFewerItemsThan 3 ) ]
+            , test "validate too long" <|
+                \() ->
+                    Encode.list
+                        [ Encode.string "foo"
+                        , Encode.string "bar"
+                        , Encode.string "baz"
+                        , Encode.string "foo"
+                        , Encode.string "bar"
+                        , Encode.string "baz"
+                        , Encode.string "foo"
+                        ]
+                        |> Validator.validate arraySchema
+                        |> Expect.equal [ ( [], Validator.HasMoreItemsThan 6 ) ]
+            , test "validate wrong item type" <|
+                \() ->
+                    Encode.list
+                        [ Encode.string "foo"
+                        , Encode.string "bar"
+                        , Encode.string "baz"
+                        , Encode.int 1
+                        , Encode.string "bar"
+                        , Encode.string "baz"
+                        ]
+                        |> Validator.validate arraySchema
+                        |> Expect.equal
+                            [ ( [ "3" ]
+                              , Validator.DecodeError "Expecting a String but instead got: 1"
+                              )
+                            ]
+            , test "validate multiple errors" <|
+                \() ->
+                    Encode.list
+                        [ Encode.string "foo"
+                        , Encode.int 1
+                        ]
+                        |> Validator.validate arraySchema
+                        |> Expect.equal
+                            [ ( [ "1" ]
+                              , Validator.DecodeError "Expecting a String but instead got: 1"
+                              )
+                            , ( [], Validator.HasFewerItemsThan 3 )
+                            ]
+            ]
+
+
+stringSchemaSpec : Test
+stringSchemaSpec =
+    let
+        stringSchema : Schema
+        stringSchema =
+            string
+                [ title "string schema title"
+                , description "string schema description"
+                , minLength 2
+                , maxLength 8
+                , pattern "f"
+                , format dateTime
+                ]
+    in
+        describe "string schema"
+            [ test "validate valid" <|
+                \() ->
+                    Encode.string "foo"
+                        |> Validator.validate stringSchema
+                        |> Expect.equal []
+            , test "validate wrong pattern" <|
+                \() ->
+                    Encode.string "goo"
+                        |> Validator.validate stringSchema
+                        |> Expect.equal [ ( [], Validator.DoesNotMatchPattern "f" ) ]
+            , test "validate too short" <|
+                \() ->
+                    Encode.string "f"
+                        |> Validator.validate stringSchema
+                        |> Expect.equal [ ( [], Validator.IsShorterThan 2 ) ]
+            , test "validate too long" <|
+                \() ->
+                    Encode.string "foooooooo"
+                        |> Validator.validate stringSchema
+                        |> Expect.equal [ ( [], Validator.IsLongerThan 8 ) ]
+            , test "validate multiple errors" <|
+                \() ->
+                    Encode.string "goooooooo"
+                        |> Validator.validate stringSchema
+                        |> Expect.equal [ ( [], Validator.IsLongerThan 8 ), ( [], Validator.DoesNotMatchPattern "f" ) ]
+            ]
+
+
+stringEnumSchemaSpec : Test
+stringEnumSchemaSpec =
+    let
+        stringEnumSchema : Schema
+        stringEnumSchema =
+            string
+                [ title "string schema title"
+                , enum [ "a", "b" ]
+                ]
+    in
+        describe "string enum schema"
+            [ test "validate valid 1" <|
+                \() ->
+                    Encode.string "a"
+                        |> Validator.validate stringEnumSchema
+                        |> Expect.equal []
+            , test "validate valid 2" <|
+                \() ->
+                    Encode.string "b"
+                        |> Validator.validate stringEnumSchema
+                        |> Expect.equal []
+            , test "validate invalid" <|
+                \() ->
+                    Encode.string "c"
+                        |> Validator.validate stringEnumSchema
+                        |> Expect.equal [ ( [], Validator.NotInEnumeration ) ]
+            ]
+
+
+integerEnumSchemaSpec : Test
+integerEnumSchemaSpec =
+    let
+        integerEnumSchema : Schema
+        integerEnumSchema =
+            integer
+                [ title "integer schema title"
+                , enum [ 1, 2 ]
+                ]
+    in
+        describe "integer enum schema"
+            [ test "validate valid 1" <|
+                \() ->
+                    Encode.int 1
+                        |> Validator.validate integerEnumSchema
+                        |> Expect.equal []
+            , test "validate valid 2" <|
+                \() ->
+                    Encode.int 2
+                        |> Validator.validate integerEnumSchema
+                        |> Expect.equal []
+            , test "validate invalid" <|
+                \() ->
+                    Encode.int 3
+                        |> Validator.validate integerEnumSchema
+                        |> Expect.equal [ ( [], Validator.NotInEnumeration ) ]
+            ]
+
+
+integerSchemaSpec : Test
+integerSchemaSpec =
+    let
+        integerSchema : Schema
+        integerSchema =
+            integer
+                [ title "integer schema title"
+                , description "integer schema description"
+                , minimum 2
+                , maximum 8
+                ]
+    in
+        describe "integer schema"
+            [ test "validate valid" <|
+                \() ->
+                    Encode.int 4
+                        |> Validator.validate integerSchema
+                        |> Expect.equal []
+            , test "validate too small" <|
+                \() ->
+                    Encode.int 1
+                        |> Validator.validate integerSchema
+                        |> Expect.equal [ ( [], Validator.IsLessThan 2 ) ]
+            , test "validate too large" <|
+                \() ->
+                    Encode.int 9
+                        |> Validator.validate integerSchema
+                        |> Expect.equal [ ( [], Validator.IsMoreThan 8 ) ]
+            ]
+
+
+numberSchemaSpec : Test
+numberSchemaSpec =
+    let
+        numberSchema : Schema
+        numberSchema =
+            number
+                [ title "number schema title"
+                , description "number schema description"
+                , minimum 2.5
+                , maximum 8.3
+                ]
+    in
+        describe "number schema"
+            [ test "validate valid" <|
+                \() ->
+                    Encode.float 4
+                        |> Validator.validate numberSchema
+                        |> Expect.equal []
+            , test "validate too small" <|
+                \() ->
+                    Encode.float 2.4
+                        |> Validator.validate numberSchema
+                        |> Expect.equal [ ( [], Validator.IsLessThan 2.5 ) ]
+            , test "validate too large" <|
+                \() ->
+                    Encode.float 8.4
+                        |> Validator.validate numberSchema
+                        |> Expect.equal [ ( [], Validator.IsMoreThan 8.3 ) ]
+            ]
+
+
+numberEnumSchemaSpec : Test
+numberEnumSchemaSpec =
+    let
+        numberEnumSchema : Schema
+        numberEnumSchema =
+            number
+                [ title "number schema title"
+                , enum [ 1.2, 3.4 ]
+                ]
+    in
+        describe "number schema"
+            [ test "validate valid 1" <|
+                \() ->
+                    Encode.float 1.2
+                        |> Validator.validate numberEnumSchema
+                        |> Expect.equal []
+            , test "validate valid 2" <|
+                \() ->
+                    Encode.float 3.4
+                        |> Validator.validate numberEnumSchema
+                        |> Expect.equal []
+            , test "validate invalid" <|
+                \() ->
+                    Encode.float 2.3
+                        |> Validator.validate numberEnumSchema
+                        |> Expect.equal [ ( [], Validator.NotInEnumeration ) ]
+            ]
+
+
+booleanSchemaSpec : Test
+booleanSchemaSpec =
+    let
+        booleanSchema : Schema
+        booleanSchema =
+            boolean
+                [ title "boolean schema title"
+                , description "boolean schema description"
+                ]
+    in
+        describe "boolean schema"
+            [ test "validate valid" <|
+                \() ->
+                    Encode.bool True
+                        |> Validator.validate booleanSchema
+                        |> Expect.equal []
+            , test "validate invalid type" <|
+                \() ->
+                    Encode.int 1
+                        |> Validator.validate booleanSchema
+                        |> Expect.equal [ ( [], Validator.DecodeError "Expecting a Bool but instead got: 1" ) ]
+            ]
+
+
+nullSchemaSpec : Test
+nullSchemaSpec =
+    let
+        nullSchema : Schema
+        nullSchema =
+            null
+                [ title "null schema title"
+                , description "null schema description"
+                ]
+    in
+        describe "null schema"
+            [ test "validate valid" <|
+                \() ->
+                    Encode.null
+                        |> Validator.validate nullSchema
+                        |> Expect.equal []
+            , test "validate invalid type" <|
+                \() ->
+                    Encode.int 1
+                        |> Validator.validate nullSchema
+                        |> Expect.equal [ ( [], Validator.DecodeError "Expecting null but instead got: 1" ) ]
+            ]
+
+
+oneOfSpec : Test
+oneOfSpec =
+    let
+        oneOfSchema =
+            oneOf
+                [ title "oneOf schema title"
+                , description "oneOf schema description"
+                ]
+                [ string [ pattern "a" ], string [ pattern "b" ] ]
+    in
+        describe "oneOf schema"
+            [ test "validate valid 1" <|
+                \() ->
+                    Encode.string "a"
+                        |> Validator.validate oneOfSchema
+                        |> Expect.equal []
+            , test "validate valid 2" <|
+                \() ->
+                    Encode.string "b"
+                        |> Validator.validate oneOfSchema
+                        |> Expect.equal []
+            , test "validate no match" <|
+                \() ->
+                    Encode.string "c"
+                        |> Validator.validate oneOfSchema
+                        |> Expect.equal [ ( [], Validator.TooFewMatches ) ]
+            , test "validate too many" <|
+                \() ->
+                    Encode.string "ab"
+                        |> Validator.validate oneOfSchema
+                        |> Expect.equal [ ( [], Validator.TooManyMatches ) ]
+            ]
+
+
+anyOfSpec : Test
+anyOfSpec =
+    let
+        anyOfSchema =
+            anyOf
+                [ title "anyOf schema title"
+                , description "anyOf schema description"
+                ]
+                [ string [ pattern "a" ], string [ pattern "b" ] ]
+    in
+        describe "anyOf schema"
+            [ test "validate valid 1" <|
+                \() ->
+                    Encode.string "a"
+                        |> Validator.validate anyOfSchema
+                        |> Expect.equal []
+            , test "validate valid 2" <|
+                \() ->
+                    Encode.string "b"
+                        |> Validator.validate anyOfSchema
+                        |> Expect.equal []
+            , test "validate valid 3" <|
+                \() ->
+                    Encode.string "ab"
+                        |> Validator.validate anyOfSchema
+                        |> Expect.equal []
+            , test "validate no match" <|
+                \() ->
+                    Encode.string "c"
+                        |> Validator.validate anyOfSchema
+                        |> Expect.equal [ ( [], Validator.TooFewMatches ) ]
+            ]
+
+
+allOfSpec : Test
+allOfSpec =
+    let
+        allOfSchema =
+            allOf
+                [ title "allOf schema title"
+                , description "allOf schema description"
+                ]
+                [ string [ pattern "a" ], string [ pattern "b" ] ]
+    in
+        describe "anyOf schema"
+            [ test "validate valid" <|
+                \() ->
+                    Encode.string "ab"
+                        |> Validator.validate allOfSchema
+                        |> Expect.equal []
+            , test "validate invalid 1" <|
+                \() ->
+                    Encode.string "a"
+                        |> Validator.validate allOfSchema
+                        |> Expect.equal [ ( [], Validator.TooFewMatches ) ]
+            , test "validate invalid 2" <|
+                \() ->
+                    Encode.string "b"
+                        |> Validator.validate allOfSchema
+                        |> Expect.equal [ ( [], Validator.TooFewMatches ) ]
+            , test "validate invalid 3" <|
+                \() ->
+                    Encode.string "c"
+                        |> Validator.validate allOfSchema
+                        |> Expect.equal [ ( [], Validator.TooFewMatches ) ]
+            ]
+
+
+lazySpec : Test
+lazySpec =
+    let
+        lazySchema =
+            oneOf []
+                [ array
+                    [ items <| lazy (\_ -> lazySchema)
+                    ]
+                , integer [ maximum 2 ]
+                ]
+    in
+        describe "anyOf schema"
+            [ test "validate valid 1" <|
+                \() ->
+                    Encode.list [ Encode.list [] ]
+                        |> Validator.validate lazySchema
+                        |> Expect.equal []
+            , test "validate valid 2" <|
+                \() ->
+                    Encode.list [ Encode.list [ Encode.int 1 ] ]
+                        |> Validator.validate lazySchema
+                        |> Expect.equal []
+            , test "validate invalid" <|
+                \() ->
+                    Encode.list [ Encode.list [ Encode.int 3 ] ]
+                        |> Validator.validate lazySchema
+                        |> Expect.equal [ ( [], Validator.TooFewMatches ) ]
+            ]


### PR DESCRIPTION
A validator implementation for #8. Error messages are a union type which may not be ideal for use in a package, perhaps they should be changed to strings.

Does not yes validate `format`, some of those formats are quite tricky.

I changed some of the tests to be able to test validation of oneOf,anyOf,allOf.