### PR TITLE
Change shrink dependency to use Noah's version

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -18,7 +18,7 @@
         "Skinney/murmur3": "2.0.4 <= v < 3.0.0",
         "elm-community/elm-test": "4.0.0 <= v < 5.0.0",
         "elm-community/maybe-extra": "3.1.0 <= v < 4.0.0",
-        "elm-community/shrink": "2.0.0 <= v < 3.0.0",
+        "eeue56/elm-shrink": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0",


### PR DESCRIPTION
`elm-community/elm-test@4.2.0` relies on `eeue56/lazy-list`, which conflicts with the `elm-community/lazy-list` dependency of `elm-community/shrink`. Both packages expose a `Lazy.List` module.

Using the same dependency here as is used in `elm-community/elm-test@4.2.0` seems like a good way to unblock people from using this without letting dependencies go out of date.